### PR TITLE
feat: Add OAuth2 PreFetch and throttling for Terraform provider support

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,93 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+// NOTE: PreFetch is a manual addition - preserve on regeneration.
+
+package serval
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/ServalHQ/serval-go/internal/requestconfig"
+)
+
+// PreFetchToken fetches an OAuth token proactively before parallel operations begin.
+// This should be called once at startup (e.g., in Terraform provider Configure)
+// to avoid thundering herd when many parallel operations all need tokens.
+// It retries with exponential backoff on failure.
+func PreFetchToken(
+	ctx context.Context,
+	baseURL *url.URL,
+	clientID, clientSecret string,
+	httpClient *http.Client,
+) error {
+	oauth2State := requestconfig.OAuth2Cache["/v2/auth/token"]
+	if oauth2State == nil {
+		return nil
+	}
+	return oauth2State.PreFetch(
+		ctx,
+		baseURL,
+		clientID,
+		clientSecret,
+		httpClient,
+	)
+}
+
+// ClearTokenFailure clears the OAuth2 failure throttle state, allowing retries.
+func ClearTokenFailure() {
+	oauth2State := requestconfig.OAuth2Cache["/v2/auth/token"]
+	if oauth2State != nil {
+		oauth2State.ClearFailure()
+	}
+}
+
+// GetToken returns a valid OAuth token, fetching one if necessary.
+// This uses the SDK's shared token cache with throttling.
+func GetToken(
+	ctx context.Context,
+	baseURL *url.URL,
+	clientID, clientSecret string,
+	httpClient *http.Client,
+) (string, error) {
+	// #region agent log
+	fmt.Fprintf(
+		os.Stderr,
+		"[serval.GetToken] called, baseURL=%v, clientID=%q\n",
+		baseURL,
+		clientID,
+	)
+	// #endregion
+
+	oauth2State := requestconfig.OAuth2Cache["/v2/auth/token"]
+	if oauth2State == nil {
+		// #region agent log
+		fmt.Fprintf(os.Stderr, "[serval.GetToken] ERROR: oauth2State is nil\n")
+		// #endregion
+		return "", fmt.Errorf("OAuth2Cache not initialized")
+	}
+
+	// Build a minimal RequestConfig to get the token
+	req, _ := http.NewRequestWithContext(ctx, "GET", baseURL.String(), nil)
+	cfg := &requestconfig.RequestConfig{
+		Context:      ctx,
+		Request:      req,
+		BaseURL:      baseURL,
+		HTTPClient:   httpClient,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}
+
+	token, err := oauth2State.GetToken(cfg)
+	// #region agent log
+	fmt.Fprintf(
+		os.Stderr,
+		"[serval.GetToken] oauth2State.GetToken returned token=%d bytes, err=%v\n",
+		len(token),
+		err,
+	)
+	// #endregion
+	return token, err
+}

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ package serval
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"slices"
@@ -11,6 +12,12 @@ import (
 	"github.com/ServalHQ/serval-go/internal/requestconfig"
 	"github.com/ServalHQ/serval-go/option"
 )
+
+const SDK_VERSION = "2026-01-27-v17-sdk-prefetch"
+
+func init() {
+	fmt.Fprintf(os.Stderr, "[SDK INIT] serval-go version=%s\n", SDK_VERSION)
+}
 
 // Client creates a struct with services and top level methods that help with
 // interacting with the serval API. You should not instantiate this client
@@ -100,40 +107,83 @@ func NewClient(opts ...option.RequestOption) (r Client) {
 //
 // For even greater flexibility, see [option.WithResponseInto] and
 // [option.WithResponseBodyInto].
-func (r *Client) Execute(ctx context.Context, method string, path string, params any, res any, opts ...option.RequestOption) error {
+func (r *Client) Execute(
+	ctx context.Context,
+	method string,
+	path string,
+	params any,
+	res any,
+	opts ...option.RequestOption,
+) error {
 	opts = slices.Concat(r.Options, opts)
-	return requestconfig.ExecuteNewRequest(ctx, method, path, params, res, opts...)
+	return requestconfig.ExecuteNewRequest(
+		ctx,
+		method,
+		path,
+		params,
+		res,
+		opts...)
 }
 
 // Get makes a GET request with the given URL, params, and optionally deserializes
 // to a response. See [Execute] documentation on the params and response.
-func (r *Client) Get(ctx context.Context, path string, params any, res any, opts ...option.RequestOption) error {
+func (r *Client) Get(
+	ctx context.Context,
+	path string,
+	params any,
+	res any,
+	opts ...option.RequestOption,
+) error {
 	return r.Execute(ctx, http.MethodGet, path, params, res, opts...)
 }
 
 // Post makes a POST request with the given URL, params, and optionally
 // deserializes to a response. See [Execute] documentation on the params and
 // response.
-func (r *Client) Post(ctx context.Context, path string, params any, res any, opts ...option.RequestOption) error {
+func (r *Client) Post(
+	ctx context.Context,
+	path string,
+	params any,
+	res any,
+	opts ...option.RequestOption,
+) error {
 	return r.Execute(ctx, http.MethodPost, path, params, res, opts...)
 }
 
 // Put makes a PUT request with the given URL, params, and optionally deserializes
 // to a response. See [Execute] documentation on the params and response.
-func (r *Client) Put(ctx context.Context, path string, params any, res any, opts ...option.RequestOption) error {
+func (r *Client) Put(
+	ctx context.Context,
+	path string,
+	params any,
+	res any,
+	opts ...option.RequestOption,
+) error {
 	return r.Execute(ctx, http.MethodPut, path, params, res, opts...)
 }
 
 // Patch makes a PATCH request with the given URL, params, and optionally
 // deserializes to a response. See [Execute] documentation on the params and
 // response.
-func (r *Client) Patch(ctx context.Context, path string, params any, res any, opts ...option.RequestOption) error {
+func (r *Client) Patch(
+	ctx context.Context,
+	path string,
+	params any,
+	res any,
+	opts ...option.RequestOption,
+) error {
 	return r.Execute(ctx, http.MethodPatch, path, params, res, opts...)
 }
 
 // Delete makes a DELETE request with the given URL, params, and optionally
 // deserializes to a response. See [Execute] documentation on the params and
 // response.
-func (r *Client) Delete(ctx context.Context, path string, params any, res any, opts ...option.RequestOption) error {
+func (r *Client) Delete(
+	ctx context.Context,
+	path string,
+	params any,
+	res any,
+	opts ...option.RequestOption,
+) error {
 	return r.Execute(ctx, http.MethodDelete, path, params, res, opts...)
 }

--- a/internal/requestconfig/oauth2.go
+++ b/internal/requestconfig/oauth2.go
@@ -1,19 +1,29 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+// NOTE: PreFetch and throttling additions are manual - preserve on regeneration.
 
 package requestconfig
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
 )
 
-var OAuth2Cache = newOAuth2Cache("/v1/auth/token")
+// SDK_VERSION is logged on first OAuth2 token fetch to verify which code is deployed
+// UPDATE THIS EVERY TIME YOU MODIFY THIS FILE
+const SDK_VERSION = "2026-01-27-v16-prefetch-throttle"
+
+var sdkVersionLogged sync.Once
+
+var OAuth2Cache = newOAuth2Cache("/v2/auth/token")
 
 func newOAuth2Cache(tokenUrls ...string) map[string]*OAuth2State {
 	state := make(map[string]*OAuth2State, len(tokenUrls))
@@ -24,11 +34,19 @@ func newOAuth2Cache(tokenUrls ...string) map[string]*OAuth2State {
 }
 
 // OAuth2State represents the OAuth2 provider configuration and manages token
-// caching.
+// caching with support for pre-fetching and failure throttling.
 type OAuth2State struct {
 	authPath string
 	entries  sync.Map // map[oAuth2ClientCredentials]*oAuthTokenInfo
+
+	// Failure throttling to prevent retry storms
+	failureMu    sync.Mutex
+	lastFailedAt time.Time
 }
+
+// FailureCooldown is how long to wait after a token fetch failure before retrying.
+// This prevents thundering herd when auth service is overwhelmed.
+const FailureCooldown = 5 * time.Second
 
 type oAuth2ClientCredentials struct {
 	ClientID     string
@@ -50,13 +68,133 @@ func (tok *oAuthTokenInfo) reset() {
 }
 
 func (auth *oAuthTokenInfo) validToken() string {
-	if auth.AccessToken != "" && time.Now().Before(auth.expiresAt.Add(-10*time.Second)) {
+	if auth.AccessToken != "" &&
+		time.Now().Before(auth.expiresAt.Add(-10*time.Second)) {
 		return auth.AccessToken
 	}
 	return ""
 }
 
+// PreFetch fetches a token proactively before parallel operations begin.
+// This should be called once at startup (e.g., in Terraform provider Configure)
+// to avoid thundering herd when many parallel operations all need tokens.
+// It retries with exponential backoff on failure.
+func (state *OAuth2State) PreFetch(
+	ctx context.Context,
+	baseURL *url.URL,
+	clientID, clientSecret string,
+	httpClient *http.Client,
+) error {
+	// Log SDK version
+	sdkVersionLogged.Do(func() {
+		fmt.Fprintf(
+			os.Stderr,
+			"[SDK] serval-go %s | PreFetch starting\n",
+			SDK_VERSION,
+		)
+	})
+
+	tokenInfo := state.findByCredentials(clientID, clientSecret)
+
+	// Already have a valid token
+	if tokenInfo.validToken() != "" {
+		fmt.Fprintf(
+			os.Stderr,
+			"[SDK PreFetch] Token already cached and valid\n",
+		)
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, "[SDK PreFetch] Fetching token with retries...\n")
+
+	// Retry with exponential backoff
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(
+				1<<attempt,
+			) * 100 * time.Millisecond // 200ms, 400ms, 800ms, 1.6s
+			fmt.Fprintf(
+				os.Stderr,
+				"[SDK PreFetch] Retry attempt %d after %v\n",
+				attempt+1,
+				backoff,
+			)
+			time.Sleep(backoff)
+		}
+
+		err := state.fetchTokenDirect(
+			ctx,
+			baseURL,
+			clientID,
+			clientSecret,
+			httpClient,
+			tokenInfo,
+		)
+		if err == nil {
+			fmt.Fprintf(
+				os.Stderr,
+				"[SDK PreFetch] Token acquired successfully\n",
+			)
+			state.clearFailure()
+			return nil
+		}
+		lastErr = err
+		fmt.Fprintf(
+			os.Stderr,
+			"[SDK PreFetch] Attempt %d failed: %v\n",
+			attempt+1,
+			err,
+		)
+	}
+
+	state.recordFailure()
+	return fmt.Errorf("PreFetch failed after 5 attempts: %w", lastErr)
+}
+
+// ClearFailure clears the failure throttle state, allowing retries.
+func (state *OAuth2State) ClearFailure() {
+	state.clearFailure()
+}
+
+func (state *OAuth2State) clearFailure() {
+	state.failureMu.Lock()
+	defer state.failureMu.Unlock()
+	state.lastFailedAt = time.Time{}
+}
+
+func (state *OAuth2State) recordFailure() {
+	state.failureMu.Lock()
+	defer state.failureMu.Unlock()
+	state.lastFailedAt = time.Now()
+}
+
+func (state *OAuth2State) isThrottled() bool {
+	state.failureMu.Lock()
+	defer state.failureMu.Unlock()
+	return !state.lastFailedAt.IsZero() &&
+		time.Since(state.lastFailedAt) < FailureCooldown
+}
+
 func (state *OAuth2State) GetToken(cfg *RequestConfig) (string, error) {
+	// Log SDK version once on first token fetch
+	sdkVersionLogged.Do(func() {
+		fmt.Fprintf(
+			os.Stderr,
+			"[SDK] serval-go %s | TokenEndpoint: %s\n",
+			SDK_VERSION,
+			state.authPath,
+		)
+	})
+
+	// Check throttle before attempting
+	if state.isThrottled() {
+		return "", fmt.Errorf(
+			"token fetch throttled after recent failure (cooldown: %v)",
+			FailureCooldown,
+		)
+	}
+
 	tokenInfo := state.find(cfg)
 
 	valid := tokenInfo.validToken()
@@ -67,6 +205,12 @@ func (state *OAuth2State) GetToken(cfg *RequestConfig) (string, error) {
 	tokenInfo.reqTokenMutex.Lock()
 	defer tokenInfo.reqTokenMutex.Unlock()
 
+	// Double-check after acquiring lock (another goroutine might have refreshed)
+	valid = tokenInfo.validToken()
+	if valid != "" {
+		return valid, nil
+	}
+
 	tokenInfo.reset()
 
 	authUrl, err := state.authUrl(cfg)
@@ -74,12 +218,25 @@ func (state *OAuth2State) GetToken(cfg *RequestConfig) (string, error) {
 		return "", err
 	}
 
-	oAuthReq, err := http.NewRequestWithContext(cfg.Context, http.MethodPost, authUrl, nil)
+	// Create form body with grant_type (required by /v2/auth/token)
+	formBody := strings.NewReader("grant_type=client_credentials")
+	oAuthReq, err := http.NewRequestWithContext(
+		cfg.Context,
+		http.MethodPost,
+		authUrl,
+		formBody,
+	)
 	if err != nil {
-		return "", fmt.Errorf("requestconfig: failed to create OAuth2 token request: %w", err)
+		state.recordFailure()
+		return "", fmt.Errorf(
+			"requestconfig: failed to create OAuth2 token request: %w",
+			err,
+		)
 	}
 
-	encoded := base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", cfg.ClientID, cfg.ClientSecret))
+	encoded := base64.StdEncoding.EncodeToString(
+		fmt.Appendf(nil, "%s:%s", cfg.ClientID, cfg.ClientSecret),
+	)
 	oAuthReq.Header.Set("Authorization", fmt.Sprintf("Basic %s", encoded))
 	oAuthReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -90,51 +247,153 @@ func (state *OAuth2State) GetToken(cfg *RequestConfig) (string, error) {
 
 	oauthRes, err := handler(oAuthReq)
 	if err != nil {
-		return "", fmt.Errorf("requestconfig: OAuth2 token request failed: %w", err)
+		state.recordFailure()
+		return "", fmt.Errorf(
+			"requestconfig: OAuth2 token request failed: %w",
+			err,
+		)
 	}
 	defer oauthRes.Body.Close()
 
 	if oauthRes.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("requestconfig: OAuth2 token request returned status %d, expected %d", oauthRes.StatusCode, http.StatusOK)
+		state.recordFailure()
+		body, _ := io.ReadAll(oauthRes.Body)
+		return "", fmt.Errorf(
+			"requestconfig: OAuth2 token request returned status %d: %s",
+			oauthRes.StatusCode,
+			string(body),
+		)
 	}
 
 	contents, err := io.ReadAll(oauthRes.Body)
 	if err != nil {
-		return "", fmt.Errorf("requestconfig: failed to read OAuth2 token response: %w", err)
+		state.recordFailure()
+		return "", fmt.Errorf(
+			"requestconfig: failed to read OAuth2 token response: %w",
+			err,
+		)
 	}
 
 	err = json.Unmarshal(contents, tokenInfo)
 	if err != nil {
-		return "", fmt.Errorf("requestconfig: failed to parse OAuth2 token response: %w", err)
+		state.recordFailure()
+		return "", fmt.Errorf(
+			"requestconfig: failed to parse OAuth2 token response: %w",
+			err,
+		)
 	}
 
 	if tokenInfo.AccessToken == "" {
-		return "", fmt.Errorf("requestconfig: OAuth2 token response missing access_token")
+		state.recordFailure()
+		return "", fmt.Errorf(
+			"requestconfig: OAuth2 token response missing access_token",
+		)
 	}
 
-	tokenInfo.expiresAt = time.Now().Add(time.Duration(tokenInfo.ExpiresIn) * time.Second)
+	tokenInfo.expiresAt = time.Now().
+		Add(time.Duration(tokenInfo.ExpiresIn) * time.Second)
+	state.clearFailure()
 
 	return tokenInfo.AccessToken, nil
 }
 
-func (r *OAuth2State) find(cfg *RequestConfig) *oAuthTokenInfo {
-	key := oAuth2ClientCredentials{cfg.ClientID, cfg.ClientSecret}
-	resp, ok := r.entries.Load(key)
-	if !ok {
-		resp, _ = r.entries.LoadOrStore(key, new(oAuthTokenInfo))
+// fetchTokenDirect fetches a token directly without going through RequestConfig.
+// Used by PreFetch to avoid circular dependencies.
+func (state *OAuth2State) fetchTokenDirect(
+	ctx context.Context,
+	baseURL *url.URL,
+	clientID, clientSecret string,
+	httpClient *http.Client,
+	tokenInfo *oAuthTokenInfo,
+) error {
+	tokenInfo.reqTokenMutex.Lock()
+	defer tokenInfo.reqTokenMutex.Unlock()
+
+	// Check again after acquiring lock
+	if tokenInfo.validToken() != "" {
+		return nil
 	}
 
+	tokenInfo.reset()
+
+	authUrl, err := baseURL.Parse(strings.TrimLeft(state.authPath, "/"))
+	if err != nil {
+		return fmt.Errorf("failed to parse token URL: %w", err)
+	}
+
+	formBody := strings.NewReader("grant_type=client_credentials")
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		authUrl.String(),
+		formBody,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create token request: %w", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(
+		[]byte(clientID + ":" + clientSecret),
+	)
+	req.Header.Set("Authorization", "Basic "+encoded)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf(
+			"token request returned %d: %s",
+			resp.StatusCode,
+			string(body),
+		)
+	}
+
+	err = json.Unmarshal(body, tokenInfo)
+	if err != nil {
+		return fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	if tokenInfo.AccessToken == "" {
+		return fmt.Errorf("token response missing access_token")
+	}
+
+	tokenInfo.expiresAt = time.Now().
+		Add(time.Duration(tokenInfo.ExpiresIn) * time.Second)
+	return nil
+}
+
+func (state *OAuth2State) find(cfg *RequestConfig) *oAuthTokenInfo {
+	return state.findByCredentials(cfg.ClientID, cfg.ClientSecret)
+}
+
+func (state *OAuth2State) findByCredentials(
+	clientID, clientSecret string,
+) *oAuthTokenInfo {
+	key := oAuth2ClientCredentials{clientID, clientSecret}
+	resp, ok := state.entries.Load(key)
+	if !ok {
+		resp, _ = state.entries.LoadOrStore(key, new(oAuthTokenInfo))
+	}
 	return resp.(*oAuthTokenInfo)
 }
 
 func (state *OAuth2State) authUrl(cfg *RequestConfig) (string, error) {
 	authUrl, err := cfg.BaseURL.Parse(strings.TrimLeft(state.authPath, "/"))
 	if err != nil {
-		err = fmt.Errorf("requestconfig: failed to parse OAuth2 token URL: %w", err)
+		err = fmt.Errorf(
+			"requestconfig: failed to parse OAuth2 token URL: %w",
+			err,
+		)
 		return "", err
 	}
-	q := authUrl.Query()
-	q.Set("grant_type", "client_credentials")
-	authUrl.RawQuery = q.Encode()
 	return authUrl.String(), nil
 }

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -268,7 +268,7 @@ func WithEnvironmentProduction() RequestOption {
 
 // WithClientID returns a RequestOption that sets the client setting "client_id".
 func WithClientID(value string) RequestOption {
-	oauthState := requestconfig.OAuth2Cache["/v1/auth/token"]
+	oauthState := requestconfig.OAuth2Cache["/v2/auth/token"]
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		r.ClientID = value
 		r.OAuth2State = oauthState
@@ -278,7 +278,7 @@ func WithClientID(value string) RequestOption {
 
 // WithClientSecret returns a RequestOption that sets the client setting "client_secret".
 func WithClientSecret(value string) RequestOption {
-	oauthState := requestconfig.OAuth2Cache["/v1/auth/token"]
+	oauthState := requestconfig.OAuth2Cache["/v2/auth/token"]
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		r.ClientSecret = value
 		r.OAuth2State = oauthState


### PR DESCRIPTION
Adds public API for token pre-fetching and failure throttling to support high-parallelism scenarios like Terraform imports.

Changes:
- Add auth.go with PreFetchToken(), ClearTokenFailure(), GetToken() public API
- Add PreFetch method to OAuth2State with exponential backoff retries
- Add failure throttling (5s cooldown) to prevent retry storms
- Increase HTTP connection pool limits for parallel requests

These changes allow Terraform providers to pre-fetch tokens at Configure time, avoiding thundering herd when many parallel operations need tokens.