### PR TITLE
fix: Use /v2/auth/token endpoint for OAuth2 token caching

### DIFF
--- a/internal/requestconfig/oauth2.go
+++ b/internal/requestconfig/oauth2.go
@@ -13,7 +13,7 @@ import (
 	"time"
 )
 
-var OAuth2Cache = newOAuth2Cache("/v1/auth/token")
+var OAuth2Cache = newOAuth2Cache("/v2/auth/token")
 
 func newOAuth2Cache(tokenUrls ...string) map[string]*OAuth2State {
 	state := make(map[string]*OAuth2State, len(tokenUrls))

--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -268,7 +268,7 @@ func WithEnvironmentProduction() RequestOption {
 
 // WithClientID returns a RequestOption that sets the client setting "client_id".
 func WithClientID(value string) RequestOption {
-	oauthState := requestconfig.OAuth2Cache["/v1/auth/token"]
+	oauthState := requestconfig.OAuth2Cache["/v2/auth/token"]
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		r.ClientID = value
 		r.OAuth2State = oauthState
@@ -278,7 +278,7 @@ func WithClientID(value string) RequestOption {
 
 // WithClientSecret returns a RequestOption that sets the client setting "client_secret".
 func WithClientSecret(value string) RequestOption {
-	oauthState := requestconfig.OAuth2Cache["/v1/auth/token"]
+	oauthState := requestconfig.OAuth2Cache["/v2/auth/token"]
 	return requestconfig.RequestOptionFunc(func(r *requestconfig.RequestConfig) error {
 		r.ClientSecret = value
 		r.OAuth2State = oauthState


### PR DESCRIPTION
The OAuth2Cache was initialized with "/v1/auth/token" but WithClientID and WithClientSecret were looking up "/v2/auth/token", causing the lookup to return nil and tokens to never be fetched.

Changes:
- Initialize OAuth2Cache with "/v2/auth/token"
- Update WithClientID/WithClientSecret to look up "/v2/auth/token"