### PR TITLE
feat: add team-scoped ListByTeam endpoints for approval procedures

### DIFF
--- a/accesspolicyapprovalprocedure.go
+++ b/accesspolicyapprovalprocedure.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 
 	"github.com/ServalHQ/serval-go/internal/apijson"
+	"github.com/ServalHQ/serval-go/internal/apiquery"
 	"github.com/ServalHQ/serval-go/internal/requestconfig"
 	"github.com/ServalHQ/serval-go/option"
 	"github.com/ServalHQ/serval-go/packages/param"
@@ -325,6 +327,53 @@ type AccessPolicyApprovalProcedureListResponseEnvelope struct {
 // Returns the unmodified JSON received from the API
 func (r AccessPolicyApprovalProcedureListResponseEnvelope) RawJSON() string { return r.JSON.raw }
 func (r *AccessPolicyApprovalProcedureListResponseEnvelope) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// List all access policy approval procedures for a team.
+func (r *AccessPolicyApprovalProcedureService) ListByTeam(ctx context.Context, query AccessPolicyApprovalProcedureListByTeamParams, opts ...option.RequestOption) (res *AccessPolicyApprovalProcedureListByTeamResponse, err error) {
+	opts = slices.Concat(r.Options, opts)
+	path := "v2/access-policy-approval-procedures"
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
+	return
+}
+
+type AccessPolicyApprovalProcedureListByTeamParams struct {
+	// The ID of the team.
+	TeamID param.Opt[string] `query:"teamId,omitzero" json:"-"`
+	// Maximum number of results to return. Default is 1000, maximum is 1000.
+	PageSize param.Opt[int64] `query:"pageSize,omitzero" json:"-"`
+	// Token for pagination. Leave empty for the first request.
+	PageToken param.Opt[string] `query:"pageToken,omitzero" json:"-"`
+	paramObj
+}
+
+// URLQuery serializes [AccessPolicyApprovalProcedureListByTeamParams]'s query
+// parameters as `url.Values`.
+func (r AccessPolicyApprovalProcedureListByTeamParams) URLQuery() (v url.Values, err error) {
+	return apiquery.MarshalWithSettings(r, apiquery.QuerySettings{
+		ArrayFormat:  apiquery.ArrayQueryFormatComma,
+		NestedFormat: apiquery.NestedQueryFormatBrackets,
+	})
+}
+
+type AccessPolicyApprovalProcedureListByTeamResponse struct {
+	// The list of access policy approval procedures for the team.
+	Data []AccessPolicyApprovalProcedure `json:"data"`
+	// Token for retrieving the next page of results. Empty if no more results.
+	NextPageToken string `json:"nextPageToken,nullable"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Data          respjson.Field
+		NextPageToken respjson.Field
+		ExtraFields   map[string]respjson.Field
+		raw           string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r AccessPolicyApprovalProcedureListByTeamResponse) RawJSON() string { return r.JSON.raw }
+func (r *AccessPolicyApprovalProcedureListByTeamResponse) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,9337 @@
+openapi: 3.1.0
+info:
+  title: Serval Public API
+  description: Serval Public API
+  contact:
+    name: Serval
+    url: https://serval.com
+    email: support@serval.com
+  license:
+    name: Serval License
+    url: https://serval.com/license
+  version: 2.0.0
+servers:
+  - url: https://public.api.serval.com
+paths:
+  /v2/access-policies/{id}:
+    get:
+      tags:
+        - Access Policy API
+      summary: Get Access Policy
+      description: Get a specific access policy by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetAccessPolicy
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the access policy.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetAccessPolicyResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Access Policy API
+      summary: Update Access Policy
+      description: Update an existing access policy.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateAccessPolicy
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the access policy.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  description: The name of the access policy.
+                description:
+                  type: string
+                  title: description
+                  description: A description of the access policy.
+                maxAccessMinutes:
+                  type: integer
+                  title: max_access_minutes
+                  format: int32
+                  description: The maximum number of minutes that access can be granted for.
+                requireBusinessJustification:
+                  type: boolean
+                  title: require_business_justification
+                  description: Whether a business justification is required when requesting access.
+                recommendedAccessMinutes:
+                  type: integer
+                  title: recommended_access_minutes
+                  format: int32
+                  description: The recommended duration in minutes for access requests (optional).
+                  nullable: true
+              title: UpdateAccessPolicyRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateAccessPolicyResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Access Policy API
+      summary: Delete Access Policy
+      description: Delete an access policy.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteAccessPolicy
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the access policy.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteAccessPolicyResponse'
+      security:
+        - BearerAuth: []
+  /v2/access-policies:
+    get:
+      tags:
+        - Access Policy API
+      summary: List Access Policies
+      description: List all access policies for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListAccessPolicies
+      parameters:
+        - name: teamId
+          in: query
+          description: The ID of the team.
+          schema:
+            type: string
+            title: team_id
+            description: The ID of the team.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListAccessPoliciesResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Access Policy API
+      summary: Create Access Policy
+      description: Create a new access policy for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateAccessPolicy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.CreateAccessPolicyRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateAccessPolicyResponse'
+      security:
+        - BearerAuth: []
+  /v2/workflows/{id}:
+    get:
+      tags:
+        - Workflow API
+      summary: Get Workflow
+      description: Get a specific workflow by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetWorkflow
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the workflow.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetWorkflowResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Workflow API
+      summary: Update Workflow
+      description: Update an existing workflow.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateWorkflow
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the workflow.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  description: The name of the workflow.
+                description:
+                  type: string
+                  title: description
+                  description: A description of the workflow.
+                type:
+                  title: type
+                  description: The type of the workflow.
+                  $ref: '#/components/schemas/svflow.pubapimodels.WorkflowType'
+                executionScope:
+                  title: execution_scope
+                  description: The execution scope of the workflow.
+                  $ref: '#/components/schemas/svflow.pubapimodels.WorkflowExecutionScope'
+                requireFormConfirmation:
+                  type: boolean
+                  title: require_form_confirmation
+                  description: Whether the workflow requires form confirmation.
+                isTemporary:
+                  type: boolean
+                  title: is_temporary
+                  description: Whether the workflow is temporary.
+                content:
+                  type: string
+                  title: content
+                  description: The content/code of the workflow.
+                parameters:
+                  type: string
+                  title: parameters
+                  description: The parameters schema of the workflow (JSON).
+              title: UpdateWorkflowRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateWorkflowResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Workflow API
+      summary: Delete Workflow
+      description: Delete a workflow.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteWorkflow
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the workflow.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteWorkflowResponse'
+      security:
+        - BearerAuth: []
+  /v2/workflows:
+    get:
+      tags:
+        - Workflow API
+      summary: List Workflows
+      description: List all workflows for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListWorkflows
+      parameters:
+        - name: teamId
+          in: query
+          description: The ID of the team.
+          schema:
+            type: string
+            title: team_id
+            description: The ID of the team.
+        - name: includeTemporary
+          in: query
+          description: Whether to include temporary workflows (optional, defaults to false).
+          schema:
+            type: boolean
+            title: include_temporary
+            description: Whether to include temporary workflows (optional, defaults to false).
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListWorkflowsResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Workflow API
+      summary: Create Workflow
+      description: Create a new workflow for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateWorkflow
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.CreateWorkflowRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateWorkflowResponse'
+      security:
+        - BearerAuth: []
+  /v2/tags/{id}:
+    get:
+      tags:
+        - Tag API
+      summary: Get Tag
+      description: Get a specific tag by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetTag
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the tag.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetTagResponse'
+      security:
+        - BearerAuth: []
+  /v2/tags:
+    get:
+      tags:
+        - Tag API
+      summary: List Tags
+      description: List all tags for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListTags
+      parameters:
+        - name: teamId
+          in: query
+          description: The ID of the team.
+          schema:
+            type: string
+            title: team_id
+            description: The ID of the team.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListTagsResponse'
+      security:
+        - BearerAuth: []
+  /v2/guidances/{id}:
+    get:
+      tags:
+        - Guidance API
+      summary: Get Guidance
+      description: Get a specific guidance by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetGuidance
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the guidance.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetGuidanceResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Guidance API
+      summary: Update Guidance
+      description: Update an existing guidance.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateGuidance
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the guidance.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  description: The name of the guidance.
+                description:
+                  type: string
+                  title: description
+                  description: A description of the guidance.
+                content:
+                  type: string
+                  title: content
+                  description: The content of the guidance.
+                shouldAlwaysUse:
+                  type: boolean
+                  title: should_always_use
+                  description: Whether this guidance should always be used (optional).
+                  nullable: true
+              title: UpdateGuidanceRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateGuidanceResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Guidance API
+      summary: Delete Guidance
+      description: Delete a guidance.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteGuidance
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the guidance.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteGuidanceResponse'
+      security:
+        - BearerAuth: []
+  /v2/guidances:
+    get:
+      tags:
+        - Guidance API
+      summary: List Guidances
+      description: List all guidances for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListGuidances
+      parameters:
+        - name: teamId
+          in: query
+          description: The ID of the team.
+          schema:
+            type: string
+            title: team_id
+            description: The ID of the team.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListGuidancesResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Guidance API
+      summary: Create Guidance
+      description: Create a new guidance for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateGuidance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.CreateGuidanceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateGuidanceResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-resources/{id}:
+    get:
+      tags:
+        - App Resource API
+      summary: Get App Resource
+      description: Get a specific app resource by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetAppResource
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the resource.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetAppResourceResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - App Resource API
+      summary: Update App Resource
+      description: Update an existing app resource.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateAppResource
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the resource.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                resourceType:
+                  type: string
+                  title: resource_type
+                  description: The type of the resource.
+                name:
+                  type: string
+                  title: name
+                  description: The name of the resource.
+                description:
+                  type: string
+                  title: description
+                  description: A description of the resource.
+                externalId:
+                  type: string
+                  title: external_id
+                  description: The external ID of the resource (optional).
+                  nullable: true
+              title: UpdateAppResourceRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateAppResourceResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - App Resource API
+      summary: Delete App Resource
+      description: Delete an app resource.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteAppResource
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the resource.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteAppResourceResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-resources:
+    get:
+      tags:
+        - App Resource API
+      summary: List App Resources
+      description: List all app resources for a team, optionally filtered by app instance.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListAppResources
+      parameters:
+        - name: teamId
+          in: query
+          description: Filter by team ID. At least one of team_id or app_instance_id must be provided.
+          schema:
+            type: string
+            title: team_id
+            description: Filter by team ID. At least one of team_id or app_instance_id must be provided.
+        - name: appInstanceId
+          in: query
+          description: Filter by app instance ID. At least one of team_id or app_instance_id must be provided.
+          schema:
+            type: string
+            title: app_instance_id
+            description: Filter by app instance ID. At least one of team_id or app_instance_id must be provided.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 5000, maximum is 5000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListAppResourcesResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - App Resource API
+      summary: Create App Resource
+      description: Create a new app resource for an app instance.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateAppResource
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.CreateAppResourceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateAppResourceResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-resources/batch:
+    put:
+      tags:
+        - App Resource API
+      summary: Batch Update App Resources
+      description: Update multiple app resources in a single transactional request. Either all updates succeed or all fail.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.BatchUpdateAppResources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.BatchUpdateAppResourcesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.BatchUpdateAppResourcesResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - App Resource API
+      summary: Batch Create App Resources
+      description: Create multiple app resources for an app instance in a single request.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.BatchCreateAppResources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.BatchCreateAppResourcesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.BatchCreateAppResourcesResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-resources/search:
+    post:
+      tags:
+        - App Resource API
+      summary: Search App Resources
+      description: Search app resources with filters in the request body. Filter by team ID, app instance IDs, or external IDs.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.SearchAppResources
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.SearchAppResourcesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.SearchAppResourcesResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-instances/{app_instance_id}/resources:
+    get:
+      summary: ListResourcesForAppInstance
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListResourcesForAppInstance
+      parameters:
+        - name: app_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: app_instance_id
+            description: The ID of the app instance.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListResourcesForAppInstanceResponse'
+      deprecated: true
+  /v2/app-resource-entitlements/{id}:
+    get:
+      summary: GetAppResourceEntitlement
+      description: App Resource Entitlement Related Endpoints (deprecated - use Role endpoints)
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetAppResourceEntitlement
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the entitlement.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetAppResourceEntitlementResponse'
+      deprecated: true
+    put:
+      summary: UpdateAppResourceEntitlement
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateAppResourceEntitlement
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the entitlement.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  description: The name of the entitlement.
+                description:
+                  type: string
+                  title: description
+                  description: A description of the entitlement.
+                requestsEnabled:
+                  type: boolean
+                  title: requests_enabled
+                  description: Whether requests are enabled for the entitlement.
+                accessPolicyId:
+                  type: string
+                  title: access_policy_id
+                  description: The default access policy for the entitlement (optional).
+                  nullable: true
+                provisioningMethod:
+                  title: provisioning_method
+                  description: Provisioning configuration. Exactly one method should be set.
+                  $ref: '#/components/schemas/svflow.pubapimodels.ProvisioningMethod'
+                externalId:
+                  type: string
+                  title: external_id
+                  description: The external ID of the entitlement in the external system (optional).
+                  nullable: true
+                externalData:
+                  type: string
+                  title: external_data
+                  description: Data from the external system as a JSON string (optional).
+                  nullable: true
+              title: UpdateAppResourceEntitlementRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateAppResourceEntitlementResponse'
+      deprecated: true
+    delete:
+      summary: DeleteAppResourceEntitlement
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteAppResourceEntitlement
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the entitlement.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteAppResourceEntitlementResponse'
+      deprecated: true
+  /v2/app-resource-entitlements:
+    get:
+      summary: ListAppResourceEntitlements
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListAppResourceEntitlements
+      parameters:
+        - name: teamId
+          in: query
+          description: Filter by team ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          schema:
+            type: string
+            title: team_id
+            description: Filter by team ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+        - name: resourceId
+          in: query
+          description: Filter by resource ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          schema:
+            type: string
+            title: resource_id
+            description: Filter by resource ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 5000, maximum is 5000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+        - name: appInstanceId
+          in: query
+          description: Filter by app instance ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          schema:
+            type: string
+            title: app_instance_id
+            description: Filter by app instance ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListAppResourceEntitlementsResponse'
+      deprecated: true
+    post:
+      summary: CreateAppResourceEntitlement
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateAppResourceEntitlement
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.CreateAppResourceEntitlementRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateAppResourceEntitlementResponse'
+      deprecated: true
+  /v2/app-resource-entitlements/batch:
+    put:
+      summary: BatchUpdateAppResourceEntitlements
+      operationId: svrelay.publicv2.PublicAPIServiceV2.BatchUpdateAppResourceEntitlements
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.BatchUpdateAppResourceEntitlementsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.BatchUpdateAppResourceEntitlementsResponse'
+      deprecated: true
+  /v2/app-resource-entitlements/search:
+    post:
+      summary: SearchAppResourceEntitlements
+      operationId: svrelay.publicv2.PublicAPIServiceV2.SearchAppResourceEntitlements
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.SearchAppResourceEntitlementsRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.SearchAppResourceEntitlementsResponse'
+      deprecated: true
+  /v2/app-resources/{resource_id}/entitlements:
+    get:
+      summary: ListEntitlementsForAppResource
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListEntitlementsForAppResource
+      parameters:
+        - name: resource_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: resource_id
+            description: The ID of the resource.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListEntitlementsForAppResourceResponse'
+      deprecated: true
+  /v2/app-resource-roles/{id}:
+    get:
+      tags:
+        - App Resource Role API
+      summary: Get App Resource Role
+      description: Get a specific app resource role by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetAppResourceRole
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the role.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetAppResourceRoleResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - App Resource Role API
+      summary: Update App Resource Role
+      description: Update an existing app resource role.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateAppResourceRole
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the role.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  description: The name of the role.
+                description:
+                  type: string
+                  title: description
+                  description: A description of the role.
+                requestsEnabled:
+                  type: boolean
+                  title: requests_enabled
+                  description: Whether requests are enabled for the role.
+                accessPolicyId:
+                  type: string
+                  title: access_policy_id
+                  description: The default access policy for the role (optional).
+                  nullable: true
+                provisioningMethod:
+                  title: provisioning_method
+                  description: Provisioning configuration. Exactly one method should be set.
+                  $ref: '#/components/schemas/svflow.pubapimodels.RoleProvisioningMethod'
+                externalId:
+                  type: string
+                  title: external_id
+                  description: The external ID of the role in the external system (optional).
+                  nullable: true
+                externalData:
+                  type: string
+                  title: external_data
+                  description: Data from the external system as a JSON string (optional).
+                  nullable: true
+              title: UpdateAppResourceRoleRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateAppResourceRoleResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - App Resource Role API
+      summary: Delete App Resource Role
+      description: Delete an app resource role.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteAppResourceRole
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the role.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteAppResourceRoleResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-resource-roles:
+    get:
+      tags:
+        - App Resource Role API
+      summary: List App Resource Roles
+      description: List all app resource roles for a team, optionally filtered by resource.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListAppResourceRoles
+      parameters:
+        - name: teamId
+          in: query
+          description: Filter by team ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          schema:
+            type: string
+            title: team_id
+            description: Filter by team ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+        - name: appInstanceId
+          in: query
+          description: Filter by app instance ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          schema:
+            type: string
+            title: app_instance_id
+            description: Filter by app instance ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+        - name: resourceId
+          in: query
+          description: Filter by resource ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          schema:
+            type: string
+            title: resource_id
+            description: Filter by resource ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 5000, maximum is 5000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListAppResourceRolesResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - App Resource Role API
+      summary: Create App Resource Role
+      description: Create a new app resource role for a resource.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateAppResourceRole
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.CreateAppResourceRoleRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateAppResourceRoleResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-resource-roles/batch:
+    put:
+      tags:
+        - App Resource Role API
+      summary: Batch Update App Resource Roles
+      description: Update multiple app resource roles in a single transactional request. Either all updates succeed or all fail.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.BatchUpdateAppResourceRoles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.BatchUpdateAppResourceRolesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.BatchUpdateAppResourceRolesResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-resource-roles/search:
+    post:
+      tags:
+        - App Resource Role API
+      summary: Search App Resource Roles
+      description: Search app resource roles with filters in the request body. Filter by team ID or resource IDs.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.SearchAppResourceRoles
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.SearchAppResourceRolesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.SearchAppResourceRolesResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-instances/{id}:
+    get:
+      tags:
+        - App Instance API
+      summary: Get App Instance
+      description: Get a specific app instance by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetAppInstance
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the app instance.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetAppInstanceResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - App Instance API
+      summary: Update App Instance
+      description: Update an existing app instance.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateAppInstance
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the app instance.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                instanceId:
+                  type: string
+                  title: instance_id
+                  description: The instance ID of the app instance.
+                name:
+                  type: string
+                  title: name
+                  description: The name of the app instance.
+                defaultAccessPolicyId:
+                  type: string
+                  title: default_access_policy_id
+                  description: The default access policy for the app instance (optional).
+                  nullable: true
+                accessRequestsEnabled:
+                  type: boolean
+                  title: access_requests_enabled
+                  description: Whether access requests are enabled for the app instance.
+              title: UpdateAppInstanceRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateAppInstanceResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - App Instance API
+      summary: Delete App Instance
+      description: Delete an app instance.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteAppInstance
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the app instance.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteAppInstanceResponse'
+      security:
+        - BearerAuth: []
+  /v2/app-instances:
+    get:
+      tags:
+        - App Instance API
+      summary: List App Instances
+      description: List all app instances for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListAppInstances
+      parameters:
+        - name: teamId
+          in: query
+          description: The ID of the team.
+          schema:
+            type: string
+            title: team_id
+            description: The ID of the team.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListAppInstancesResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - App Instance API
+      summary: Create App Instance
+      description: Create a new app instance for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateAppInstance
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.CreateAppInstanceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateAppInstanceResponse'
+      security:
+        - BearerAuth: []
+  /v2/custom-services/{id}:
+    get:
+      tags:
+        - Custom Service API
+      summary: Get Custom Service
+      description: Get a specific custom service by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetCustomService
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the custom service.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetCustomServiceResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Custom Service API
+      summary: Update Custom Service
+      description: Update an existing custom service.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateCustomService
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the custom service.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  description: The name of the custom service.
+                domain:
+                  type: string
+                  title: domain
+                  description: The domain for branding/logo lookup.
+              title: UpdateCustomServiceRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateCustomServiceResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Custom Service API
+      summary: Delete Custom Service
+      description: Delete a custom service. This will not delete any app instances that use this custom service.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteCustomService
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the custom service.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteCustomServiceResponse'
+      security:
+        - BearerAuth: []
+  /v2/custom-services:
+    get:
+      tags:
+        - Custom Service API
+      summary: List Custom Services
+      description: List all custom services for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListCustomServices
+      parameters:
+        - name: teamId
+          in: query
+          description: The ID of the team.
+          schema:
+            type: string
+            title: team_id
+            description: The ID of the team.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListCustomServicesResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Custom Service API
+      summary: Create Custom Service
+      description: Create a new custom service for a team. Custom services represent external APIs or systems that are not built-in integrations.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateCustomService
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svflow.publicapi.CreateCustomServiceRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateCustomServiceResponse'
+      security:
+        - BearerAuth: []
+  /v2/access-policies/{access_policy_id}/approval-procedures/{id}:
+    get:
+      tags:
+        - Access Policy Approval Procedure API
+      summary: Get Access Policy Approval Procedure
+      description: Get a specific approval procedure by ID for an access policy.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetAccessPolicyApprovalProcedure
+      parameters:
+        - name: access_policy_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: access_policy_id
+            description: The ID of the access policy.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the approval procedure.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetAccessPolicyApprovalProcedureResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Access Policy Approval Procedure API
+      summary: Update Access Policy Approval Procedure
+      description: Update an existing approval procedure for an access policy.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateAccessPolicyApprovalProcedure
+      parameters:
+        - name: access_policy_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: access_policy_id
+            description: The ID of the access policy.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the approval procedure.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                steps:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+                  title: steps
+                  description: The approval steps for the procedure.
+              title: UpdateAccessPolicyApprovalProcedureRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateAccessPolicyApprovalProcedureResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Access Policy Approval Procedure API
+      summary: Delete Access Policy Approval Procedure
+      description: Delete an approval procedure for an access policy.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteAccessPolicyApprovalProcedure
+      parameters:
+        - name: access_policy_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: access_policy_id
+            description: The ID of the access policy.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the approval procedure.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteAccessPolicyApprovalProcedureResponse'
+      security:
+        - BearerAuth: []
+  /v2/access-policies/{access_policy_id}/approval-procedures:
+    get:
+      tags:
+        - Access Policy Approval Procedure API
+      summary: List Access Policy Approval Procedures
+      description: List all approval procedures for an access policy.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListAccessPolicyApprovalProcedures
+      parameters:
+        - name: access_policy_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: access_policy_id
+            description: The ID of the access policy to list approval procedures for.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListAccessPolicyApprovalProceduresResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Access Policy Approval Procedure API
+      summary: Create Access Policy Approval Procedure
+      description: Create a new approval procedure for an access policy.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateAccessPolicyApprovalProcedure
+      parameters:
+        - name: access_policy_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: access_policy_id
+            description: The ID of the access policy to create the approval procedure for.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                steps:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+                  title: steps
+                  description: The approval steps for the procedure.
+              title: CreateAccessPolicyApprovalProcedureRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateAccessPolicyApprovalProcedureResponse'
+      security:
+        - BearerAuth: []
+  /v2/workflows/{workflow_id}/approval-procedures/{id}:
+    get:
+      tags:
+        - Workflow Approval Procedure API
+      summary: Get Workflow Approval Procedure
+      description: Get a specific approval procedure by ID for a workflow.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetWorkflowApprovalProcedure
+      parameters:
+        - name: workflow_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: workflow_id
+            description: The ID of the workflow.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the approval procedure.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.GetWorkflowApprovalProcedureResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Workflow Approval Procedure API
+      summary: Update Workflow Approval Procedure
+      description: Update an existing approval procedure for a workflow.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateWorkflowApprovalProcedure
+      parameters:
+        - name: workflow_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: workflow_id
+            description: The ID of the workflow.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the approval procedure.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                steps:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+                  title: steps
+                  description: The approval steps for the procedure.
+              title: UpdateWorkflowApprovalProcedureRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.UpdateWorkflowApprovalProcedureResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Workflow Approval Procedure API
+      summary: Delete Workflow Approval Procedure
+      description: Delete an approval procedure for a workflow.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteWorkflowApprovalProcedure
+      parameters:
+        - name: workflow_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: workflow_id
+            description: The ID of the workflow.
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the approval procedure.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.DeleteWorkflowApprovalProcedureResponse'
+      security:
+        - BearerAuth: []
+  /v2/workflows/{workflow_id}/approval-procedures:
+    get:
+      tags:
+        - Workflow Approval Procedure API
+      summary: List Workflow Approval Procedures
+      description: List all approval procedures for a workflow.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListWorkflowApprovalProcedures
+      parameters:
+        - name: workflow_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: workflow_id
+            description: The ID of the workflow to list approval procedures for.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListWorkflowApprovalProceduresResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Workflow Approval Procedure API
+      summary: Create Workflow Approval Procedure
+      description: Create a new approval procedure for a workflow.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateWorkflowApprovalProcedure
+      parameters:
+        - name: workflow_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: workflow_id
+            description: The ID of the workflow to create the approval procedure for.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                steps:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+                  title: steps
+                  description: The approval steps for the procedure.
+              title: CreateWorkflowApprovalProcedureRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.CreateWorkflowApprovalProcedureResponse'
+      security:
+        - BearerAuth: []
+  /v2/workflow-approval-procedures:
+    get:
+      tags:
+        - Workflow Approval Procedure API
+      summary: List Team Workflow Approval Procedures
+      description: 'List all workflow approval procedures for a team.'
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListTeamWorkflowApprovalProcedures
+      parameters:
+        - name: teamId
+          in: query
+          description: The ID of the team.
+          schema:
+            type: string
+            title: team_id
+            description: The ID of the team.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListTeamWorkflowApprovalProceduresResponse'
+      security:
+        - BearerAuth: []
+      x-hidden: true
+  /v2/access-policy-approval-procedures:
+    get:
+      tags:
+        - Access Policy Approval Procedure API
+      summary: List Team Access Policy Approval Procedures
+      description: 'List all access policy approval procedures for a team.'
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListTeamAccessPolicyApprovalProcedures
+      parameters:
+        - name: teamId
+          in: query
+          description: The ID of the team.
+          schema:
+            type: string
+            title: team_id
+            description: The ID of the team.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svflow.publicapi.ListTeamAccessPolicyApprovalProceduresResponse'
+      security:
+        - BearerAuth: []
+      x-hidden: true
+  /v2/users:
+    get:
+      tags:
+        - User API
+      summary: List Users
+      description: List all users.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListUsers
+      parameters:
+        - name: includeDeactivated
+          in: query
+          description: Whether to include deactivated users in the response.
+          schema:
+            type: boolean
+            title: include_deactivated
+            description: Whether to include deactivated users in the response.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.ListUsersResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - User API
+      summary: Create User
+      description: Create a new user.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svauth.public.CreateUserRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.CreateUserResponse'
+      security:
+        - BearerAuth: []
+  /v2/users/{id}:
+    get:
+      tags:
+        - User API
+      summary: Get User
+      description: Get a specific user by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetUser
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.GetUserResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - User API
+      summary: Update User
+      description: Update an existing user.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateUser
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  title: email
+                  nullable: true
+                firstName:
+                  type: string
+                  title: first_name
+                  nullable: true
+                lastName:
+                  type: string
+                  title: last_name
+                  nullable: true
+                role:
+                  title: role
+                  nullable: true
+                  $ref: '#/components/schemas/svauth.public.UserOrganizationRole'
+                avatarUrl:
+                  type: string
+                  title: avatar_url
+                  nullable: true
+              title: UpdateUserRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.UpdateUserResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - User API
+      summary: Delete User
+      description: Delete a user.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteUser
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.DeleteUserResponse'
+      security:
+        - BearerAuth: []
+  /v2/groups:
+    get:
+      tags:
+        - Group API
+      summary: List Groups
+      description: List all groups.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListGroups
+      parameters:
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 5000, maximum is 5000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.ListGroupsResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Group API
+      summary: Create Group
+      description: Create a new group.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateGroup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svauth.public.CreateGroupRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.CreateGroupResponse'
+      security:
+        - BearerAuth: []
+  /v2/groups/{id}:
+    get:
+      tags:
+        - Group API
+      summary: Get Group
+      description: Get a specific group by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetGroup
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.GetGroupResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Group API
+      summary: Update Group
+      description: Update an existing group.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateGroup
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  nullable: true
+                userIds:
+                  type: array
+                  items:
+                    type: string
+                  title: user_ids
+              title: UpdateGroupRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.UpdateGroupResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Group API
+      summary: Delete Group
+      description: Delete a group.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteGroup
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.DeleteGroupResponse'
+      security:
+        - BearerAuth: []
+  /v2/teams:
+    get:
+      tags:
+        - Team API
+      summary: List Teams
+      description: List all teams.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListTeams
+      parameters:
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.ListTeamsResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Team API
+      summary: Create Team
+      description: Create a new team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateTeam
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svauth.public.CreateTeamRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.CreateTeamResponse'
+      security:
+        - BearerAuth: []
+  /v2/teams/{id}:
+    get:
+      tags:
+        - Team API
+      summary: Get Team
+      description: Get a specific team by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetTeam
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.GetTeamResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Team API
+      summary: Update Team
+      description: Update an existing team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateTeam
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  nullable: true
+                prefix:
+                  type: string
+                  title: prefix
+                  nullable: true
+                description:
+                  type: string
+                  title: description
+                  nullable: true
+                userIds:
+                  type: array
+                  items:
+                    type: string
+                  title: user_ids
+              title: UpdateTeamRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.UpdateTeamResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Team API
+      summary: Delete Team
+      description: Delete a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteTeam
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svauth.public.DeleteTeamResponse'
+      security:
+        - BearerAuth: []
+  /v2/tickets:
+    get:
+      tags:
+        - Ticket API
+      summary: List Tickets
+      description: List tickets for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListTickets
+      parameters:
+        - name: teamId
+          in: query
+          schema:
+            type: string
+            title: team_id
+        - name: startTime.seconds
+          in: query
+          description: |-
+            Represents seconds of UTC time since Unix epoch
+             1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+             9999-12-31T23:59:59Z inclusive.
+          schema:
+            type:
+              - integer
+              - string
+            title: seconds
+            format: int64
+            description: |-
+              Represents seconds of UTC time since Unix epoch
+               1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+               9999-12-31T23:59:59Z inclusive.
+        - name: startTime.nanos
+          in: query
+          description: |-
+            Non-negative fractions of a second at nanosecond resolution. Negative
+             second values with fractions must still have non-negative nanos values
+             that count forward in time. Must be from 0 to 999,999,999
+             inclusive.
+          schema:
+            type: integer
+            title: nanos
+            format: int32
+            description: |-
+              Non-negative fractions of a second at nanosecond resolution. Negative
+               second values with fractions must still have non-negative nanos values
+               that count forward in time. Must be from 0 to 999,999,999
+               inclusive.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.ListTicketsResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Ticket API
+      summary: Create Ticket
+      description: Create a new ticket.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateTicket
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svhelp.publicapi.CreateTicketRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.CreateTicketResponse'
+      security:
+        - BearerAuth: []
+  /v2/tickets/{id}:
+    get:
+      tags:
+        - Ticket API
+      summary: Get Ticket
+      description: Get a specific ticket by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetTicket
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.GetTicketResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Ticket API
+      summary: Update Ticket
+      description: Update an existing ticket.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateTicket
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  nullable: true
+                description:
+                  type: string
+                  title: description
+                  nullable: true
+                statusId:
+                  type: string
+                  title: status_id
+                  nullable: true
+                priorityId:
+                  type: string
+                  title: priority_id
+                  nullable: true
+                assignedToUserId:
+                  type: string
+                  title: assigned_to_user_id
+                  nullable: true
+                labelIds:
+                  type: array
+                  items:
+                    type: string
+                  title: label_ids
+                slaStartedAt:
+                  title: sla_started_at
+                  nullable: true
+                  $ref: '#/components/schemas/google.protobuf.Timestamp'
+                slaBreachesAt:
+                  title: sla_breaches_at
+                  nullable: true
+                  $ref: '#/components/schemas/google.protobuf.Timestamp'
+                escalationLevel:
+                  title: escalation_level
+                  nullable: true
+                  $ref: '#/components/schemas/svhelp.models.TicketEscalationLevel'
+                requesterUserId:
+                  type: string
+                  title: requester_user_id
+                  nullable: true
+              title: UpdateTicketRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.UpdateTicketResponse'
+      security:
+        - BearerAuth: []
+  /v2/labels:
+    get:
+      tags:
+        - Ticket API
+      summary: List Labels
+      description: List labels for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListLabels
+      parameters:
+        - name: teamId
+          in: query
+          schema:
+            type: string
+            title: team_id
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.ListLabelsResponse'
+      security:
+        - BearerAuth: []
+  /v2/statuses:
+    get:
+      tags:
+        - Ticket API
+      summary: List Statuses
+      description: List statuses for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListStatuses
+      parameters:
+        - name: teamId
+          in: query
+          schema:
+            type: string
+            title: team_id
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.ListStatusesResponse'
+      security:
+        - BearerAuth: []
+  /v2/priorities:
+    get:
+      tags:
+        - Ticket API
+      summary: List Priorities
+      description: List priorities for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListPriorities
+      parameters:
+        - name: teamId
+          in: query
+          schema:
+            type: string
+            title: team_id
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.ListPrioritiesResponse'
+      security:
+        - BearerAuth: []
+  /v2/tickets/{ticket_id}/subscribers:
+    get:
+      tags:
+        - Ticket API
+      summary: List Ticket Subscribers
+      description: List all subscribers for a ticket.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListTicketSubscribers
+      parameters:
+        - name: ticket_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: ticket_id
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.ListTicketSubscribersResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Ticket API
+      summary: Create Ticket Subscribers
+      description: Add subscribers to a ticket.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateTicketSubscribers
+      parameters:
+        - name: ticket_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: ticket_id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userIds:
+                  type: array
+                  items:
+                    type: string
+                  title: user_ids
+              title: CreateTicketSubscribersRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.CreateTicketSubscribersResponse'
+      security:
+        - BearerAuth: []
+  /v2/tickets/{ticket_id}/subscribers/{user_id}:
+    delete:
+      tags:
+        - Ticket API
+      summary: Delete Ticket Subscriber
+      description: Remove a subscriber from a ticket.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteTicketSubscribers
+      parameters:
+        - name: ticket_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: ticket_id
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: user_id
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.DeleteTicketSubscribersResponse'
+      security:
+        - BearerAuth: []
+  /v2/tickets/{ticket_id}/sync:
+    post:
+      tags:
+        - Ticket API
+      summary: Sync Ticket to Channel
+      description: Sync an existing Serval ticket to a channel by creating an external ticket in that channel and establishing ongoing bidirectional sync. Supports ticket sources (Jira, Linear, ServiceNow, etc.) and direct messaging channels (Slack DM, Email).
+      operationId: svrelay.publicv2.PublicAPIServiceV2.SyncTicketToChannel
+      parameters:
+        - name: ticket_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: ticket_id
+            description: The Serval ticket ID to sync
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channelTarget:
+                  title: channel_target
+                  description: The channel to sync to (creates external ticket and establishes ongoing sync)
+                  $ref: '#/components/schemas/svhelp.pubapimodels.ChannelTarget'
+              title: SyncTicketToChannelRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.SyncTicketToChannelResponse'
+      security:
+        - BearerAuth: []
+  /v2/tickets/{ticket_id}/connect:
+    post:
+      tags:
+        - Ticket API
+      summary: Connect to External Ticket
+      description: Connect an existing Serval ticket to an existing external ticket in a sync channel. This establishes ongoing bidirectional sync between the tickets without creating a new external ticket. The external ticket must already exist in the target system.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ConnectTicketToExternalTicket
+      parameters:
+        - name: ticket_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: ticket_id
+            description: The Serval ticket ID to connect
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                channelTarget:
+                  title: channel_target
+                  description: The channel containing the external ticket
+                  $ref: '#/components/schemas/svhelp.pubapimodels.ChannelTarget'
+                externalTicketId:
+                  type: string
+                  title: external_ticket_id
+                  description: |-
+                    The external ticket ID (which depends on the channel type)
+                     but should be a globally unique identifier for the external ticket
+                externalTicketData:
+                  title: external_ticket_data
+                  description: |-
+                    Optional: Raw external ticket data/metadata to store with the connection.
+                     This should be the JSON-serialized external ticket object from the external system.
+                     For ServiceNow, this should be the RequestedItem or Incident object.
+                     If not provided, external links may not display correctly.
+                  nullable: true
+                  $ref: '#/components/schemas/google.protobuf.Struct'
+                externalTicketSubtype:
+                  type: string
+                  title: external_ticket_subtype
+                  description: |-
+                    Optional: Subtype of the external ticket within the integration.
+                     For ServiceNow, use "incident" or "requested_item" to specify the type.
+                     This determines which sync handler is used for ongoing synchronization.
+                  nullable: true
+              title: ConnectTicketToExternalTicketRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.ConnectTicketToExternalTicketResponse'
+      security:
+        - BearerAuth: []
+  /v2/tickets/{ticket_id}/disconnect/{source_id}:
+    delete:
+      tags:
+        - Ticket API
+      summary: Disconnect from External Ticket
+      description: Disconnect a Serval ticket from an external sync channel. This stops bidirectional sync with the specified external system. Useful when moving a ticket from one channel to another (e.g., email to Slack DM). The external ticket connection is soft-deleted, preserving historical data.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DisconnectTicketFromExternalTicket
+      parameters:
+        - name: ticket_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: ticket_id
+            description: The Serval ticket ID to disconnect from
+        - name: source_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: source_id
+            description: |-
+              The source ID (connected service ID or integration ID) to disconnect
+               This identifies which external system/channel to stop syncing with
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.DisconnectTicketFromExternalTicketResponse'
+      security:
+        - BearerAuth: []
+  /v2/tickets/{ticket_id}/external-tickets:
+    get:
+      tags:
+        - Ticket API
+      summary: List Ticket External Tickets
+      description: List all external tickets linked to a Serval ticket. This shows all the external systems (Jira, Linear, ServiceNow, etc.) where this ticket is synced. Use the is_origin field to identify the original source of the ticket.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListTicketExternalTickets
+      parameters:
+        - name: ticket_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: ticket_id
+            description: The ID of the Serval ticket to list external tickets for
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.ListTicketExternalTicketsResponse'
+      security:
+        - BearerAuth: []
+  /v2/tickets/{ticket_id}/external-messages:
+    get:
+      tags:
+        - Ticket API
+      summary: List Ticket External Messages
+      description: List all origin external messages for a ticket. These are messages that originated from external systems and were synced into Serval. This helps you understand which messages came from which external channels.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListTicketExternalMessages
+      parameters:
+        - name: ticket_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: ticket_id
+            description: The ID of the Serval ticket to list external messages for
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.ListTicketExternalMessagesResponse'
+      security:
+        - BearerAuth: []
+  /v2/ticket-relationships/{id}:
+    get:
+      tags:
+        - Ticket API
+      summary: Get Ticket Relationship
+      description: Get a ticket relationship by its ID. The relationship object contains the ticket_id, related_ticket_id, and relationship_type (linked, duplicate, or parent).
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetTicketRelationship
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the ticket relationship
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svhelp.publicapi.GetTicketRelationshipResponse'
+      security:
+        - BearerAuth: []
+  /v2/audit-logs:
+    get:
+      tags:
+        - Audit Log API
+      summary: List Audit Logs
+      description: List audit logs for your organization. You can optionally filter by time range.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListAuditLogs
+      parameters:
+        - name: pageToken
+          in: query
+          schema:
+            type: string
+            title: page_token
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+        - name: startTime.seconds
+          in: query
+          description: |-
+            Represents seconds of UTC time since Unix epoch
+             1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+             9999-12-31T23:59:59Z inclusive.
+          schema:
+            type:
+              - integer
+              - string
+            title: seconds
+            format: int64
+            description: |-
+              Represents seconds of UTC time since Unix epoch
+               1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+               9999-12-31T23:59:59Z inclusive.
+        - name: startTime.nanos
+          in: query
+          description: |-
+            Non-negative fractions of a second at nanosecond resolution. Negative
+             second values with fractions must still have non-negative nanos values
+             that count forward in time. Must be from 0 to 999,999,999
+             inclusive.
+          schema:
+            type: integer
+            title: nanos
+            format: int32
+            description: |-
+              Non-negative fractions of a second at nanosecond resolution. Negative
+               second values with fractions must still have non-negative nanos values
+               that count forward in time. Must be from 0 to 999,999,999
+               inclusive.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svlog.publicapi.ListAuditLogsResponse'
+      security:
+        - BearerAuth: []
+  /v2/entities/{id}:
+    get:
+      tags:
+        - Entity API
+      summary: Get Entity
+      description: Get a specific entity by ID.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.GetEntity
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the entity.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svstore.publicapi.GetEntityResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags:
+        - Entity API
+      summary: Update Entity
+      description: Update an existing entity.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.UpdateEntity
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the entity.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  title: name
+                  description: The name of the entity.
+                fieldValues:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/svstore.pubapimodels.EntityFieldValue'
+                  title: field_values
+                  description: The field values to update.
+              title: UpdateEntityRequest
+              additionalProperties: false
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svstore.publicapi.UpdateEntityResponse'
+      security:
+        - BearerAuth: []
+    delete:
+      tags:
+        - Entity API
+      summary: Delete Entity
+      description: Delete an entity.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.DeleteEntity
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: id
+            description: The ID of the entity.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svstore.publicapi.DeleteEntityResponse'
+      security:
+        - BearerAuth: []
+  /v2/entities:
+    get:
+      tags:
+        - Entity API
+      summary: List Entities
+      description: List entities for a team. Optionally filter by entity type.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.ListEntities
+      parameters:
+        - name: teamId
+          in: query
+          description: The ID of the team.
+          schema:
+            type: string
+            title: team_id
+            description: The ID of the team.
+        - name: entityTypeId
+          in: query
+          description: Optional filter by entity type ID.
+          schema:
+            type: string
+            title: entity_type_id
+            description: Optional filter by entity type ID.
+        - name: pageSize
+          in: query
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          schema:
+            type: integer
+            title: page_size
+            format: int32
+            description: Maximum number of results to return. Default is 1000, maximum is 1000.
+        - name: pageToken
+          in: query
+          description: Token for pagination. Leave empty for the first request.
+          schema:
+            type: string
+            title: page_token
+            description: Token for pagination. Leave empty for the first request.
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svstore.publicapi.ListEntitiesResponse'
+      security:
+        - BearerAuth: []
+    post:
+      tags:
+        - Entity API
+      summary: Create Entity
+      description: Create a new entity for a team.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.CreateEntity
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svstore.publicapi.CreateEntityRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svstore.publicapi.CreateEntityResponse'
+      security:
+        - BearerAuth: []
+  /v2/entities/search:
+    post:
+      tags:
+        - Entity API
+      summary: Search Entities
+      description: Search entities with advanced filtering, sorting, and pagination. Supports filtering by entity type, name search, field filters (with OR between filter groups and AND within groups), and custom sorting.
+      operationId: svrelay.publicv2.PublicAPIServiceV2.SearchEntities
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/svstore.publicapi.SearchEntitiesRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/svstore.publicapi.SearchEntitiesResponse'
+      security:
+        - BearerAuth: []
+components:
+  schemas:
+    google.protobuf.NullValue:
+      type: string
+      title: NullValue
+      enum:
+        - NULL_VALUE
+      description: |-
+        `NullValue` is a singleton enumeration to represent the null value for the
+         `Value` type union.
+
+         The JSON representation for `NullValue` is JSON `null`.
+    svauth.public.UserOrganizationRole:
+      type: string
+      title: UserOrganizationRole
+      enum:
+        - USER_ROLE_UNSPECIFIED
+        - USER_ROLE_ORG_MEMBER
+        - USER_ROLE_ORG_ADMIN
+    svflow.pubapimodels.ManualProvisioningAssigneeType:
+      type: string
+      title: ManualProvisioningAssigneeType
+      enum:
+        - MANUAL_PROVISIONING_ASSIGNEE_TYPE_UNSPECIFIED
+        - MANUAL_PROVISIONING_ASSIGNEE_TYPE_USER
+        - MANUAL_PROVISIONING_ASSIGNEE_TYPE_GROUP
+    svflow.pubapimodels.WorkflowExecutionScope:
+      type: string
+      title: WorkflowExecutionScope
+      enum:
+        - WORKFLOW_EXECUTION_SCOPE_UNSPECIFIED
+        - TEAM_PRIVATE
+        - TEAM_PUBLIC
+    svflow.pubapimodels.WorkflowType:
+      type: string
+      title: WorkflowType
+      enum:
+        - WORKFLOW_TYPE_UNSPECIFIED
+        - EXECUTABLE
+        - GUIDANCE
+    svhelp.models.TicketEscalationLevel:
+      type: string
+      title: TicketEscalationLevel
+      enum:
+        - AI
+        - HUMAN
+    svhelp.models.TicketStatusGroup:
+      type: string
+      title: TicketStatusGroup
+      enum:
+        - TICKET_STATUS_GROUP_UNSPECIFIED
+        - TODO
+        - IN_PROGRESS
+        - DONE
+        - CANCELED
+    svhelp.models.TicketType:
+      type: string
+      title: TicketType
+      enum:
+        - TICKET_TYPE_UNSPECIFIED
+        - TICKET_TYPE_REQUEST
+        - TICKET_TYPE_TASK
+        - TICKET_TYPE_INCIDENT
+    svhelp.pubapimodels.ChannelSyncTargetUserType:
+      type: string
+      title: ChannelSyncTargetUserType
+      enum:
+        - CHANNEL_SYNC_USER_TYPE_UNSPECIFIED
+        - CHANNEL_SYNC_TARGET_USER_TICKET_ASSIGNEE
+        - CHANNEL_SYNC_TARGET_USER_TICKET_REQUESTOR
+    svhelp.pubapimodels.ExternalMessageSourceType:
+      type: string
+      title: ExternalMessageSourceType
+      enum:
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_UNSPECIFIED
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_SLACK
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_LINEAR
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_EMAIL
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_JIRA
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_PUBLIC_API
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_FRESHSERVICE
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_ZENDESK
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_SERVICENOW
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_PHONE_CALL
+        - EXTERNAL_MESSAGE_SOURCE_TYPE_MICROSOFT
+      description: External message source types
+    svhelp.pubapimodels.ExternalTicketSourceType:
+      type: string
+      title: ExternalTicketSourceType
+      enum:
+        - EXTERNAL_TICKET_SOURCE_TYPE_UNSPECIFIED
+        - EXTERNAL_TICKET_SOURCE_TYPE_LINEAR
+        - EXTERNAL_TICKET_SOURCE_TYPE_JIRA
+        - EXTERNAL_TICKET_SOURCE_TYPE_EMAIL
+        - EXTERNAL_TICKET_SOURCE_TYPE_CSV_IMPORT
+        - EXTERNAL_TICKET_SOURCE_TYPE_PUBLIC_API
+        - EXTERNAL_TICKET_SOURCE_TYPE_FRESHSERVICE
+        - EXTERNAL_TICKET_SOURCE_TYPE_SLACK
+        - EXTERNAL_TICKET_SOURCE_TYPE_ZENDESK
+        - EXTERNAL_TICKET_SOURCE_TYPE_SERVICENOW
+        - EXTERNAL_TICKET_SOURCE_TYPE_PHONE_CALL
+        - EXTERNAL_TICKET_SOURCE_TYPE_MICROSOFT
+      description: External ticket source types
+    svhelp.pubapimodels.TicketRelationshipType:
+      type: string
+      title: TicketRelationshipType
+      enum:
+        - TICKET_RELATIONSHIP_TYPE_UNSPECIFIED
+        - TICKET_RELATIONSHIP_TYPE_DUPLICATE
+        - TICKET_RELATIONSHIP_TYPE_LINKED
+        - TICKET_RELATIONSHIP_TYPE_PARENT
+      description: TicketRelationshipType represents the type of relationship between two tickets
+    svstore.pubapimodels.ComparisonOperator:
+      type: string
+      title: ComparisonOperator
+      enum:
+        - COMPARISON_OPERATOR_UNSPECIFIED
+        - EQ
+        - NE
+        - GT
+        - GTE
+        - LT
+        - LTE
+        - CONTAINS
+        - IS_NULL
+        - IS_NOT_NULL
+      description: Comparison operators for entity field filtering
+    google.protobuf.ListValue:
+      type: object
+      properties:
+        values:
+          type: array
+          items:
+            $ref: '#/components/schemas/google.protobuf.Value'
+          title: values
+          description: Repeated field of dynamically typed values.
+      title: ListValue
+      additionalProperties: false
+      description: |-
+        `ListValue` is a wrapper around a repeated field of values.
+
+         The JSON representation for `ListValue` is JSON array.
+    google.protobuf.Struct:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/google.protobuf.Value'
+      description: |-
+        `Struct` represents a structured data value, consisting of fields
+         which map to dynamically typed values. In some languages, `Struct`
+         might be supported by a native representation. For example, in
+         scripting languages like JS a struct is represented as an
+         object. The details of that representation are described together
+         with the proto support for the language.
+
+         The JSON representation for `Struct` is JSON object.
+    google.protobuf.Struct.FieldsEntry:
+      type: object
+      properties:
+        key:
+          type: string
+          title: key
+        value:
+          title: value
+          $ref: '#/components/schemas/google.protobuf.Value'
+      title: FieldsEntry
+      additionalProperties: false
+    google.protobuf.Timestamp:
+      type: string
+      examples:
+        - 1s
+        - 1.000340012s
+      format: date-time
+      description: |-
+        A Timestamp represents a point in time independent of any time zone or local
+         calendar, encoded as a count of seconds and fractions of seconds at
+         nanosecond resolution. The count is relative to an epoch at UTC midnight on
+         January 1, 1970, in the proleptic Gregorian calendar which extends the
+         Gregorian calendar backwards to year one.
+
+         All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+         second table is needed for interpretation, using a [24-hour linear
+         smear](https://developers.google.com/time/smear).
+
+         The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+         restricting to that range, we ensure that we can convert to and from [RFC
+         3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+
+         # Examples
+
+         Example 1: Compute Timestamp from POSIX `time()`.
+
+             Timestamp timestamp;
+             timestamp.set_seconds(time(NULL));
+             timestamp.set_nanos(0);
+
+         Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+
+             struct timeval tv;
+             gettimeofday(&tv, NULL);
+
+             Timestamp timestamp;
+             timestamp.set_seconds(tv.tv_sec);
+             timestamp.set_nanos(tv.tv_usec * 1000);
+
+         Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+
+             FILETIME ft;
+             GetSystemTimeAsFileTime(&ft);
+             UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+
+             // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+             // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+             Timestamp timestamp;
+             timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+             timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+
+         Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+
+             long millis = System.currentTimeMillis();
+
+             Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+                 .setNanos((int) ((millis % 1000) * 1000000)).build();
+
+         Example 5: Compute Timestamp from Java `Instant.now()`.
+
+             Instant now = Instant.now();
+
+             Timestamp timestamp =
+                 Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+                     .setNanos(now.getNano()).build();
+
+         Example 6: Compute Timestamp from current time in Python.
+
+             timestamp = Timestamp()
+             timestamp.GetCurrentTime()
+
+         # JSON Mapping
+
+         In JSON format, the Timestamp type is encoded as a string in the
+         [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+         format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+         where {year} is always expressed using four digits while {month}, {day},
+         {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+         seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+         are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+         is required. A proto3 JSON serializer should always use UTC (as indicated by
+         "Z") when printing the Timestamp type and a proto3 JSON parser should be
+         able to accept both UTC and other timezones (as indicated by an offset).
+
+         For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+         01:30 UTC on January 15, 2017.
+
+         In JavaScript, one can convert a Date object to this format using the
+         standard
+         [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+         method. In Python, a standard `datetime.datetime` object can be converted
+         to this format using
+         [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+         the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+         the Joda Time's [`ISODateTimeFormat.dateTime()`](
+         http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
+         ) to obtain a formatter capable of generating timestamps in this format.
+    google.protobuf.Value:
+      oneOf:
+        - type: "null"
+        - type: number
+        - type: string
+        - type: boolean
+        - type: array
+        - type: object
+          additionalProperties: true
+      description: |-
+        `Value` represents a dynamically typed value which can be either
+         null, a number, a string, a boolean, a recursive struct value, or a
+         list of values. A producer of value is expected to set one of these
+         variants. Absence of any variant indicates an error.
+
+         The JSON representation for `Value` is JSON value.
+    svauth.models.Actor:
+      type: object
+      oneOf:
+        - properties:
+            system:
+              title: system
+              $ref: '#/components/schemas/svauth.models.SystemActor'
+          title: system
+          required:
+            - system
+        - properties:
+            user:
+              title: user
+              $ref: '#/components/schemas/svauth.models.UserActor'
+          title: user
+          required:
+            - user
+        - properties:
+            worker:
+              title: worker
+              $ref: '#/components/schemas/svauth.models.WorkerActor'
+          title: worker
+          required:
+            - worker
+      properties:
+        id:
+          type: string
+          title: id
+      title: Actor
+      additionalProperties: false
+    svauth.models.SystemActor:
+      type: object
+      properties:
+        displayName:
+          type: string
+          title: display_name
+          description: Use to simplify display / export for audit logs
+      title: SystemActor
+      additionalProperties: false
+    svauth.models.UserActor:
+      type: object
+      properties:
+        displayName:
+          type: string
+          title: display_name
+          description: Use to simplify display / export for audit logs
+        email:
+          type: string
+          title: email
+        name:
+          type: string
+          title: name
+      title: UserActor
+      additionalProperties: false
+    svauth.models.WorkerActor:
+      type: object
+      properties:
+        displayName:
+          type: string
+          title: display_name
+          description: Use to simplify display / export for audit logs
+      title: WorkerActor
+      additionalProperties: false
+    svauth.public.CreateGroupRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          title: name
+        userIds:
+          type: array
+          items:
+            type: string
+          title: user_ids
+      title: CreateGroupRequest
+      additionalProperties: false
+    svauth.public.CreateGroupResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svauth.public.Group'
+      title: CreateGroupResponse
+      additionalProperties: false
+    svauth.public.CreateTeamRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          title: name
+        prefix:
+          type: string
+          title: prefix
+          nullable: true
+        description:
+          type: string
+          title: description
+          nullable: true
+        userIds:
+          type: array
+          items:
+            type: string
+          title: user_ids
+      title: CreateTeamRequest
+      additionalProperties: false
+    svauth.public.CreateTeamResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svauth.public.Team'
+      title: CreateTeamResponse
+      additionalProperties: false
+    svauth.public.CreateUserRequest:
+      type: object
+      properties:
+        email:
+          type: string
+          title: email
+        firstName:
+          type: string
+          title: first_name
+        lastName:
+          type: string
+          title: last_name
+        role:
+          title: role
+          $ref: '#/components/schemas/svauth.public.UserOrganizationRole'
+      title: CreateUserRequest
+      additionalProperties: false
+    svauth.public.CreateUserResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svauth.public.User'
+      title: CreateUserResponse
+      additionalProperties: false
+    svauth.public.DeleteGroupRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: DeleteGroupRequest
+      additionalProperties: false
+    svauth.public.DeleteGroupResponse:
+      type: object
+      title: DeleteGroupResponse
+      additionalProperties: false
+    svauth.public.DeleteTeamRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: DeleteTeamRequest
+      additionalProperties: false
+    svauth.public.DeleteTeamResponse:
+      type: object
+      title: DeleteTeamResponse
+      additionalProperties: false
+    svauth.public.DeleteUserRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: DeleteUserRequest
+      additionalProperties: false
+    svauth.public.DeleteUserResponse:
+      type: object
+      title: DeleteUserResponse
+      additionalProperties: false
+    svauth.public.GetGroupRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: GetGroupRequest
+      additionalProperties: false
+    svauth.public.GetGroupResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svauth.public.Group'
+      title: GetGroupResponse
+      additionalProperties: false
+    svauth.public.GetTeamRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: GetTeamRequest
+      additionalProperties: false
+    svauth.public.GetTeamResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svauth.public.Team'
+      title: GetTeamResponse
+      additionalProperties: false
+    svauth.public.GetUserRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: GetUserRequest
+      additionalProperties: false
+    svauth.public.GetUserResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svauth.public.User'
+      title: GetUserResponse
+      additionalProperties: false
+    svauth.public.Group:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        name:
+          type: string
+          title: name
+        organizationId:
+          type: string
+          title: organization_id
+        createdAt:
+          title: created_at
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        deletedAt:
+          title: deleted_at
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        userIds:
+          type: array
+          items:
+            type: string
+          title: user_ids
+      title: Group
+      additionalProperties: false
+    svauth.public.ListGroupsRequest:
+      type: object
+      properties:
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListGroupsRequest
+      additionalProperties: false
+    svauth.public.ListGroupsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svauth.public.Group'
+          title: data
+          description: The list of groups.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListGroupsResponse
+      additionalProperties: false
+    svauth.public.ListTeamsRequest:
+      type: object
+      properties:
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListTeamsRequest
+      additionalProperties: false
+    svauth.public.ListTeamsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svauth.public.Team'
+          title: data
+          description: The list of teams.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListTeamsResponse
+      additionalProperties: false
+    svauth.public.ListUsersRequest:
+      type: object
+      properties:
+        includeDeactivated:
+          type: boolean
+          title: include_deactivated
+          description: Whether to include deactivated users in the response.
+          nullable: true
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListUsersRequest
+      additionalProperties: false
+    svauth.public.ListUsersResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svauth.public.User'
+          title: data
+          description: The list of users.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListUsersResponse
+      additionalProperties: false
+    svauth.public.Team:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        name:
+          type: string
+          title: name
+        prefix:
+          type: string
+          title: prefix
+        description:
+          type: string
+          title: description
+        organizationId:
+          type: string
+          title: organization_id
+        createdAt:
+          title: created_at
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        userIds:
+          type: array
+          items:
+            type: string
+          title: user_ids
+      title: Team
+      additionalProperties: false
+    svauth.public.UpdateGroupRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        name:
+          type: string
+          title: name
+          nullable: true
+        userIds:
+          type: array
+          items:
+            type: string
+          title: user_ids
+      title: UpdateGroupRequest
+      additionalProperties: false
+    svauth.public.UpdateGroupResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svauth.public.Group'
+      title: UpdateGroupResponse
+      additionalProperties: false
+    svauth.public.UpdateTeamRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        name:
+          type: string
+          title: name
+          nullable: true
+        prefix:
+          type: string
+          title: prefix
+          nullable: true
+        description:
+          type: string
+          title: description
+          nullable: true
+        userIds:
+          type: array
+          items:
+            type: string
+          title: user_ids
+      title: UpdateTeamRequest
+      additionalProperties: false
+    svauth.public.UpdateTeamResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svauth.public.Team'
+      title: UpdateTeamResponse
+      additionalProperties: false
+    svauth.public.UpdateUserRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        email:
+          type: string
+          title: email
+          nullable: true
+        firstName:
+          type: string
+          title: first_name
+          nullable: true
+        lastName:
+          type: string
+          title: last_name
+          nullable: true
+        role:
+          title: role
+          nullable: true
+          $ref: '#/components/schemas/svauth.public.UserOrganizationRole'
+        avatarUrl:
+          type: string
+          title: avatar_url
+          nullable: true
+      title: UpdateUserRequest
+      additionalProperties: false
+    svauth.public.UpdateUserResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svauth.public.User'
+      title: UpdateUserResponse
+      additionalProperties: false
+    svauth.public.User:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        email:
+          type: string
+          title: email
+        firstName:
+          type: string
+          title: first_name
+        lastName:
+          type: string
+          title: last_name
+        name:
+          type: string
+          title: name
+        role:
+          title: role
+          $ref: '#/components/schemas/svauth.public.UserOrganizationRole'
+        avatarUrl:
+          type: string
+          title: avatar_url
+        createdAt:
+          title: created_at
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        deactivatedAt:
+          title: deactivated_at
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+      title: User
+      additionalProperties: false
+    svflow.pubapimodels.AccessPolicy:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the access policy.
+        name:
+          type: string
+          title: name
+          description: The name of the access policy.
+        description:
+          type: string
+          title: description
+          description: A description of the access policy.
+        maxAccessMinutes:
+          type: integer
+          title: max_access_minutes
+          format: int32
+          description: The maximum number of minutes that access can be granted for.
+        requireBusinessJustification:
+          type: boolean
+          title: require_business_justification
+          description: Whether a business justification is required when requesting access.
+        recommendedAccessMinutes:
+          type: integer
+          title: recommended_access_minutes
+          format: int32
+          description: The recommended duration in minutes for access requests (optional).
+          nullable: true
+      title: AccessPolicy
+      additionalProperties: false
+    svflow.pubapimodels.AccessPolicyApprovalProcedure:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the access policy approval procedure.
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The ID of the access policy this approval procedure belongs to.
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+          title: steps
+          description: The steps in the approval procedure.
+      title: AccessPolicyApprovalProcedure
+      additionalProperties: false
+    svflow.pubapimodels.AppInstance:
+      type: object
+      oneOf:
+        - properties:
+            customServiceId:
+              type: string
+              title: custom_service_id
+              description: The ID of the custom service (for custom apps).
+          title: custom_service_id
+          required:
+            - customServiceId
+        - properties:
+            service:
+              type: string
+              title: service
+              description: The service identifier (for built-in services like "github", "okta", "aws").
+          title: service
+          required:
+            - service
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the app instance.
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the Serval team that the app instance belongs to.
+        instanceId:
+          type: string
+          title: instance_id
+          description: The instance ID of the app instance.
+        name:
+          type: string
+          title: name
+          description: The name of the app instance.
+        accessRequestsEnabled:
+          type: boolean
+          title: access_requests_enabled
+          description: Whether access requests are enabled for the app instance.
+        defaultAccessPolicyId:
+          type: string
+          title: default_access_policy_id
+          description: The default access policy for the app instance.
+          nullable: true
+      title: AppInstance
+      additionalProperties: false
+    svflow.pubapimodels.ApprovalStep:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the approval step.
+        specificUserIds:
+          type: array
+          items:
+            type: string
+          title: specific_user_ids
+          description: The IDs of the specific users that can approve the step.
+        servalGroupIds:
+          type: array
+          items:
+            type: string
+          title: serval_group_ids
+          description: The IDs of the Serval groups that can approve the step.
+        allowSelfApproval:
+          type: boolean
+          title: allow_self_approval
+          description: Whether the step can be approved by the requester themselves.
+        customWorkflowId:
+          type: string
+          title: custom_workflow_id
+          description: A workflow ID to execute to determine the approvers for this step (or to auto-approve the step).
+      title: ApprovalStep
+      additionalProperties: false
+    svflow.pubapimodels.BuiltinWorkflowProvisioning:
+      type: object
+      title: BuiltinWorkflowProvisioning
+      additionalProperties: false
+      description: Provisioning is handled by the service's builtin workflow integration.
+    svflow.pubapimodels.CustomService:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the custom service.
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team that the custom service belongs to.
+        name:
+          type: string
+          title: name
+          description: The name of the custom service (e.g., "Internal HR System").
+        domain:
+          type: string
+          title: domain
+          description: The domain for branding/logo lookup (e.g., "hr.company.com").
+      title: CustomService
+      additionalProperties: false
+    svflow.pubapimodels.CustomWorkflowProvisioning:
+      type: object
+      properties:
+        provisionWorkflowId:
+          type: string
+          title: provision_workflow_id
+          description: The workflow ID to provision access.
+        deprovisionWorkflowId:
+          type: string
+          title: deprovision_workflow_id
+          description: The workflow ID to deprovision access.
+      title: CustomWorkflowProvisioning
+      additionalProperties: false
+      description: Provisioning is handled by custom workflows for provision + deprovision.
+    svflow.pubapimodels.Entitlement:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the entitlement.
+        resourceId:
+          type: string
+          title: resource_id
+          description: The ID of the resource that the entitlement belongs to.
+        name:
+          type: string
+          title: name
+          description: The name of the entitlement.
+        description:
+          type: string
+          title: description
+          description: A description of the entitlement.
+        requestsEnabled:
+          type: boolean
+          title: requests_enabled
+          description: Whether requests are enabled for the entitlement.
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The default access policy for the entitlement.
+          nullable: true
+        provisioningMethod:
+          title: provisioning_method
+          description: Provisioning configuration. **Exactly one method should be set.**
+          $ref: '#/components/schemas/svflow.pubapimodels.ProvisioningMethod'
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the entitlement in the external system (optional).
+          nullable: true
+        externalData:
+          type: string
+          title: external_data
+          description: Data from the external system as a JSON string (optional).
+          nullable: true
+      title: Entitlement
+      additionalProperties: false
+    svflow.pubapimodels.Guidance:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the guidance.
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team that the guidance belongs to.
+        name:
+          type: string
+          title: name
+          description: The name of the guidance.
+        description:
+          type: string
+          title: description
+          description: A description of the guidance.
+        content:
+          type: string
+          title: content
+          description: The content of the guidance.
+        shouldAlwaysUse:
+          type: boolean
+          title: should_always_use
+          description: Whether this guidance should always be used (skipping LLM selection).
+        isPublished:
+          type: boolean
+          title: is_published
+          description: Whether the guidance has been published at least once.
+        hasUnpublishedChanges:
+          type: boolean
+          title: has_unpublished_changes
+          description: Whether there are unpublished changes to the guidance.
+      title: Guidance
+      additionalProperties: false
+    svflow.pubapimodels.LinkedEntitlementsProvisioning:
+      type: object
+      properties:
+        linkedEntitlementIds:
+          type: array
+          items:
+            type: string
+          title: linked_entitlement_ids
+          description: The IDs of prerequisite entitlements.
+      title: LinkedEntitlementsProvisioning
+      additionalProperties: false
+      description: Provisioning depends on prerequisite entitlements being provisioned first.
+    svflow.pubapimodels.LinkedRolesProvisioning:
+      type: object
+      properties:
+        linkedRoleIds:
+          type: array
+          items:
+            type: string
+          title: linked_role_ids
+          description: The IDs of prerequisite roles.
+      title: LinkedRolesProvisioning
+      additionalProperties: false
+      description: Provisioning depends on prerequisite roles being provisioned first.
+    svflow.pubapimodels.ManualProvisioning:
+      type: object
+      properties:
+        assignees:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.ManualProvisioningAssignee'
+          title: assignees
+          description: Users and groups that should be assigned/notified for manual provisioning.
+      title: ManualProvisioning
+      additionalProperties: false
+      description: Provisioning is handled manually by assigned users/groups.
+    svflow.pubapimodels.ManualProvisioningAssignee:
+      type: object
+      properties:
+        assigneeId:
+          type: string
+          title: assignee_id
+          description: The ID of the user or group.
+        assigneeType:
+          title: assignee_type
+          description: The type of assignee.
+          $ref: '#/components/schemas/svflow.pubapimodels.ManualProvisioningAssigneeType'
+      title: ManualProvisioningAssignee
+      additionalProperties: false
+    svflow.pubapimodels.ProvisioningMethod:
+      type: object
+      oneOf:
+        - properties:
+            builtinWorkflow:
+              title: builtin_workflow
+              $ref: '#/components/schemas/svflow.pubapimodels.BuiltinWorkflowProvisioning'
+          title: builtin_workflow
+          required:
+            - builtinWorkflow
+        - properties:
+            customWorkflow:
+              title: custom_workflow
+              $ref: '#/components/schemas/svflow.pubapimodels.CustomWorkflowProvisioning'
+          title: custom_workflow
+          required:
+            - customWorkflow
+        - properties:
+            linkedEntitlements:
+              title: linked_entitlements
+              $ref: '#/components/schemas/svflow.pubapimodels.LinkedEntitlementsProvisioning'
+          title: linked_entitlements
+          required:
+            - linkedEntitlements
+        - properties:
+            manual:
+              title: manual
+              $ref: '#/components/schemas/svflow.pubapimodels.ManualProvisioning'
+          title: manual
+          required:
+            - manual
+      title: ProvisioningMethod
+      additionalProperties: false
+      description: |-
+        Provisioning configuration for an entitlement.
+         Exactly one method should be set.
+    svflow.pubapimodels.Resource:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the resource.
+        appInstanceId:
+          type: string
+          title: app_instance_id
+          description: The ID of the app instance that the resource belongs to.
+        resourceType:
+          type: string
+          title: resource_type
+          description: The type of the resource.
+        name:
+          type: string
+          title: name
+          description: The name of the resource.
+        description:
+          type: string
+          title: description
+          description: A description of the resource.
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the resource.
+          nullable: true
+      title: Resource
+      additionalProperties: false
+    svflow.pubapimodels.Role:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the role.
+        resourceId:
+          type: string
+          title: resource_id
+          description: The ID of the resource that the role belongs to.
+        name:
+          type: string
+          title: name
+          description: The name of the role.
+        description:
+          type: string
+          title: description
+          description: A description of the role.
+        requestsEnabled:
+          type: boolean
+          title: requests_enabled
+          description: Whether requests are enabled for the role.
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The default access policy for the role.
+          nullable: true
+        provisioningMethod:
+          title: provisioning_method
+          description: Provisioning configuration. **Exactly one method should be set.**
+          $ref: '#/components/schemas/svflow.pubapimodels.RoleProvisioningMethod'
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the role in the external system (optional).
+          nullable: true
+        externalData:
+          type: string
+          title: external_data
+          description: Data from the external system as a JSON string (optional).
+          nullable: true
+      title: Role
+      additionalProperties: false
+      description: Role represents a requestable role on an app resource.
+    svflow.pubapimodels.RoleProvisioningMethod:
+      type: object
+      oneOf:
+        - properties:
+            builtinWorkflow:
+              title: builtin_workflow
+              $ref: '#/components/schemas/svflow.pubapimodels.BuiltinWorkflowProvisioning'
+          title: builtin_workflow
+          required:
+            - builtinWorkflow
+        - properties:
+            customWorkflow:
+              title: custom_workflow
+              $ref: '#/components/schemas/svflow.pubapimodels.CustomWorkflowProvisioning'
+          title: custom_workflow
+          required:
+            - customWorkflow
+        - properties:
+            linkedRoles:
+              title: linked_roles
+              $ref: '#/components/schemas/svflow.pubapimodels.LinkedRolesProvisioning'
+          title: linked_roles
+          required:
+            - linkedRoles
+        - properties:
+            manual:
+              title: manual
+              $ref: '#/components/schemas/svflow.pubapimodels.ManualProvisioning'
+          title: manual
+          required:
+            - manual
+      title: RoleProvisioningMethod
+      additionalProperties: false
+      description: |-
+        Provisioning configuration for a role.
+         Exactly one method should be set.
+    svflow.pubapimodels.Tag:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the tag.
+        name:
+          type: string
+          title: name
+          description: The name of the tag.
+        color:
+          type: string
+          title: color
+          description: The color of the tag (CSS color string).
+          nullable: true
+        iconSlug:
+          type: string
+          title: icon_slug
+          description: The icon slug for the tag.
+          nullable: true
+      title: Tag
+      additionalProperties: false
+      description: A tag that can be associated with workflows.
+    svflow.pubapimodels.Workflow:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the workflow.
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team that the workflow belongs to.
+        name:
+          type: string
+          title: name
+          description: The name of the workflow.
+        description:
+          type: string
+          title: description
+          description: A description of the workflow.
+        type:
+          title: type
+          description: The type of the workflow.
+          $ref: '#/components/schemas/svflow.pubapimodels.WorkflowType'
+        executionScope:
+          title: execution_scope
+          description: The execution scope of the workflow.
+          $ref: '#/components/schemas/svflow.pubapimodels.WorkflowExecutionScope'
+        requireFormConfirmation:
+          type: boolean
+          title: require_form_confirmation
+          description: Whether the workflow requires form confirmation.
+        isTemporary:
+          type: boolean
+          title: is_temporary
+          description: Whether the workflow is temporary.
+        content:
+          type: string
+          title: content
+          description: The content/code of the workflow.
+        parameters:
+          type: string
+          title: parameters
+          description: The parameters schema of the workflow (JSON).
+        isPublished:
+          type: boolean
+          title: is_published
+          description: Whether the workflow has been published at least once.
+        hasUnpublishedChanges:
+          type: boolean
+          title: has_unpublished_changes
+          description: Whether there are unpublished changes to the workflow.
+        tagIds:
+          type: array
+          items:
+            type: string
+          title: tag_ids
+          description: IDs of tags associated with this workflow.
+      title: Workflow
+      additionalProperties: false
+    svflow.pubapimodels.WorkflowApprovalProcedure:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the workflow approval procedure.
+        workflowId:
+          type: string
+          title: workflow_id
+          description: The ID of the workflow this approval procedure belongs to.
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+          title: steps
+          description: The steps in the approval procedure.
+      title: WorkflowApprovalProcedure
+      additionalProperties: false
+    svflow.publicapi.BatchCreateAppResourcesRequest:
+      type: object
+      properties:
+        appInstanceId:
+          type: string
+          title: app_instance_id
+          description: The ID of the app instance to create resources under.
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.publicapi.CreateAppResourceInput'
+          title: resources
+          description: The resources to create.
+      title: BatchCreateAppResourcesRequest
+      additionalProperties: false
+    svflow.publicapi.BatchCreateAppResourcesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Resource'
+          title: data
+          description: The created resources.
+      title: BatchCreateAppResourcesResponse
+      additionalProperties: false
+    svflow.publicapi.BatchUpdateAppResourceEntitlementsRequest:
+      type: object
+      properties:
+        entitlements:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.publicapi.UpdateAppResourceEntitlementInput'
+          title: entitlements
+          description: The entitlements to update.
+      title: BatchUpdateAppResourceEntitlementsRequest
+      additionalProperties: false
+    svflow.publicapi.BatchUpdateAppResourceEntitlementsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Entitlement'
+          title: data
+          description: The updated entitlements.
+      title: BatchUpdateAppResourceEntitlementsResponse
+      additionalProperties: false
+    svflow.publicapi.BatchUpdateAppResourceRolesRequest:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.publicapi.UpdateAppResourceRoleInput'
+          title: roles
+          description: The roles to update.
+      title: BatchUpdateAppResourceRolesRequest
+      additionalProperties: false
+    svflow.publicapi.BatchUpdateAppResourceRolesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Role'
+          title: data
+          description: The updated roles.
+      title: BatchUpdateAppResourceRolesResponse
+      additionalProperties: false
+    svflow.publicapi.BatchUpdateAppResourcesRequest:
+      type: object
+      properties:
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.publicapi.UpdateAppResourceInput'
+          title: resources
+          description: The resources to update.
+      title: BatchUpdateAppResourcesRequest
+      additionalProperties: false
+    svflow.publicapi.BatchUpdateAppResourcesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Resource'
+          title: data
+          description: The updated resources.
+      title: BatchUpdateAppResourcesResponse
+      additionalProperties: false
+    svflow.publicapi.CreateAccessPolicyApprovalProcedureRequest:
+      type: object
+      properties:
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The ID of the access policy to create the approval procedure for.
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+          title: steps
+          description: The approval steps for the procedure.
+      title: CreateAccessPolicyApprovalProcedureRequest
+      additionalProperties: false
+    svflow.publicapi.CreateAccessPolicyApprovalProcedureResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created approval procedure.
+          $ref: '#/components/schemas/svflow.pubapimodels.AccessPolicyApprovalProcedure'
+      title: CreateAccessPolicyApprovalProcedureResponse
+      additionalProperties: false
+    svflow.publicapi.CreateAccessPolicyRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        name:
+          type: string
+          title: name
+          description: The name of the access policy.
+        description:
+          type: string
+          title: description
+          description: A description of the access policy.
+        maxAccessMinutes:
+          type: integer
+          title: max_access_minutes
+          format: int32
+          description: The maximum number of minutes that access can be granted for (optional).
+          nullable: true
+        requireBusinessJustification:
+          type: boolean
+          title: require_business_justification
+          description: Whether a business justification is required when requesting access (optional).
+          nullable: true
+        recommendedAccessMinutes:
+          type: integer
+          title: recommended_access_minutes
+          format: int32
+          description: The recommended duration in minutes for access requests (optional).
+          nullable: true
+      title: CreateAccessPolicyRequest
+      additionalProperties: false
+    svflow.publicapi.CreateAccessPolicyResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created access policy.
+          $ref: '#/components/schemas/svflow.pubapimodels.AccessPolicy'
+      title: CreateAccessPolicyResponse
+      additionalProperties: false
+    svflow.publicapi.CreateAppInstanceRequest:
+      type: object
+      oneOf:
+        - properties:
+            customServiceId:
+              type: string
+              title: custom_service_id
+              description: The ID of a custom service to create the app instance for.
+          title: custom_service_id
+          required:
+            - customServiceId
+        - properties:
+            service:
+              type: string
+              title: service
+              description: The service identifier (for built-in services like "github", "okta", "aws").
+          title: service
+          required:
+            - service
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        instanceId:
+          type: string
+          title: instance_id
+          description: The instance ID of the app instance.
+        name:
+          type: string
+          title: name
+          description: The name of the app instance.
+        defaultAccessPolicyId:
+          type: string
+          title: default_access_policy_id
+          description: The default access policy for the app instance (optional).
+          nullable: true
+        accessRequestsEnabled:
+          type: boolean
+          title: access_requests_enabled
+          description: Whether access requests are enabled for the app instance.
+      title: CreateAppInstanceRequest
+      additionalProperties: false
+    svflow.publicapi.CreateAppInstanceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created app instance.
+          $ref: '#/components/schemas/svflow.pubapimodels.AppInstance'
+      title: CreateAppInstanceResponse
+      additionalProperties: false
+    svflow.publicapi.CreateAppResourceEntitlementRequest:
+      type: object
+      properties:
+        resourceId:
+          type: string
+          title: resource_id
+          description: The ID of the resource.
+        name:
+          type: string
+          title: name
+          description: The name of the entitlement.
+        description:
+          type: string
+          title: description
+          description: A description of the entitlement.
+        requestsEnabled:
+          type: boolean
+          title: requests_enabled
+          description: Whether requests are enabled for the entitlement.
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The default access policy for the entitlement (optional).
+          nullable: true
+        provisioningMethod:
+          title: provisioning_method
+          description: Provisioning configuration. Exactly one method should be set.
+          $ref: '#/components/schemas/svflow.pubapimodels.ProvisioningMethod'
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the entitlement in the external system (optional).
+          nullable: true
+        externalData:
+          type: string
+          title: external_data
+          description: Data from the external system as a JSON string (optional).
+          nullable: true
+      title: CreateAppResourceEntitlementRequest
+      additionalProperties: false
+    svflow.publicapi.CreateAppResourceEntitlementResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created entitlement.
+          $ref: '#/components/schemas/svflow.pubapimodels.Entitlement'
+      title: CreateAppResourceEntitlementResponse
+      additionalProperties: false
+    svflow.publicapi.CreateAppResourceInput:
+      type: object
+      properties:
+        resourceType:
+          type: string
+          title: resource_type
+          description: The type of the resource.
+        name:
+          type: string
+          title: name
+          description: The name of the resource.
+        description:
+          type: string
+          title: description
+          description: A description of the resource.
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the resource (optional).
+          nullable: true
+      title: CreateAppResourceInput
+      additionalProperties: false
+    svflow.publicapi.CreateAppResourceRequest:
+      type: object
+      properties:
+        appInstanceId:
+          type: string
+          title: app_instance_id
+          description: The ID of the app instance.
+        resourceType:
+          type: string
+          title: resource_type
+          description: The type of the resource.
+        name:
+          type: string
+          title: name
+          description: The name of the resource.
+        description:
+          type: string
+          title: description
+          description: A description of the resource.
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the resource (optional).
+          nullable: true
+      title: CreateAppResourceRequest
+      additionalProperties: false
+    svflow.publicapi.CreateAppResourceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created resource.
+          $ref: '#/components/schemas/svflow.pubapimodels.Resource'
+      title: CreateAppResourceResponse
+      additionalProperties: false
+    svflow.publicapi.CreateAppResourceRoleRequest:
+      type: object
+      properties:
+        resourceId:
+          type: string
+          title: resource_id
+          description: The ID of the resource.
+        name:
+          type: string
+          title: name
+          description: The name of the role.
+        description:
+          type: string
+          title: description
+          description: A description of the role.
+        requestsEnabled:
+          type: boolean
+          title: requests_enabled
+          description: Whether requests are enabled for the role.
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The default access policy for the role (optional).
+          nullable: true
+        provisioningMethod:
+          title: provisioning_method
+          description: Provisioning configuration. Exactly one method should be set.
+          $ref: '#/components/schemas/svflow.pubapimodels.RoleProvisioningMethod'
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the role in the external system (optional).
+          nullable: true
+        externalData:
+          type: string
+          title: external_data
+          description: Data from the external system as a JSON string (optional).
+          nullable: true
+      title: CreateAppResourceRoleRequest
+      additionalProperties: false
+    svflow.publicapi.CreateAppResourceRoleResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created role.
+          $ref: '#/components/schemas/svflow.pubapimodels.Role'
+      title: CreateAppResourceRoleResponse
+      additionalProperties: false
+    svflow.publicapi.CreateCustomServiceRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        name:
+          type: string
+          title: name
+          description: The name of the custom service (e.g., "Internal HR System").
+        domain:
+          type: string
+          title: domain
+          description: The domain for branding/logo lookup (e.g., "hr.company.com").
+      title: CreateCustomServiceRequest
+      additionalProperties: false
+    svflow.publicapi.CreateCustomServiceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created custom service.
+          $ref: '#/components/schemas/svflow.pubapimodels.CustomService'
+      title: CreateCustomServiceResponse
+      additionalProperties: false
+    svflow.publicapi.CreateGuidanceRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        name:
+          type: string
+          title: name
+          description: The name of the guidance.
+        description:
+          type: string
+          title: description
+          description: A description of the guidance.
+        content:
+          type: string
+          title: content
+          description: The content of the guidance (optional).
+          nullable: true
+        shouldAlwaysUse:
+          type: boolean
+          title: should_always_use
+          description: Whether this guidance should always be used (optional, defaults to false).
+          nullable: true
+      title: CreateGuidanceRequest
+      additionalProperties: false
+    svflow.publicapi.CreateGuidanceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created guidance.
+          $ref: '#/components/schemas/svflow.pubapimodels.Guidance'
+      title: CreateGuidanceResponse
+      additionalProperties: false
+    svflow.publicapi.CreateWorkflowApprovalProcedureRequest:
+      type: object
+      properties:
+        workflowId:
+          type: string
+          title: workflow_id
+          description: The ID of the workflow to create the approval procedure for.
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+          title: steps
+          description: The approval steps for the procedure.
+      title: CreateWorkflowApprovalProcedureRequest
+      additionalProperties: false
+    svflow.publicapi.CreateWorkflowApprovalProcedureResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created approval procedure.
+          $ref: '#/components/schemas/svflow.pubapimodels.WorkflowApprovalProcedure'
+      title: CreateWorkflowApprovalProcedureResponse
+      additionalProperties: false
+    svflow.publicapi.CreateWorkflowRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        name:
+          type: string
+          title: name
+          description: The name of the workflow.
+        description:
+          type: string
+          title: description
+          description: A description of the workflow.
+        type:
+          title: type
+          description: The type of the workflow.
+          $ref: '#/components/schemas/svflow.pubapimodels.WorkflowType'
+        executionScope:
+          title: execution_scope
+          description: The execution scope of the workflow.
+          $ref: '#/components/schemas/svflow.pubapimodels.WorkflowExecutionScope'
+        requireFormConfirmation:
+          type: boolean
+          title: require_form_confirmation
+          description: Whether the workflow requires form confirmation (optional).
+          nullable: true
+        isTemporary:
+          type: boolean
+          title: is_temporary
+          description: Whether the workflow is temporary (optional).
+          nullable: true
+        content:
+          type: string
+          title: content
+          description: The content/code of the workflow (optional).
+          nullable: true
+        parameters:
+          type: string
+          title: parameters
+          description: The parameters schema of the workflow (JSON, optional).
+          nullable: true
+      title: CreateWorkflowRequest
+      additionalProperties: false
+    svflow.publicapi.CreateWorkflowResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created workflow.
+          $ref: '#/components/schemas/svflow.pubapimodels.Workflow'
+      title: CreateWorkflowResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteAccessPolicyApprovalProcedureRequest:
+      type: object
+      properties:
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The ID of the access policy.
+        id:
+          type: string
+          title: id
+          description: The ID of the approval procedure.
+      title: DeleteAccessPolicyApprovalProcedureRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteAccessPolicyApprovalProcedureResponse:
+      type: object
+      title: DeleteAccessPolicyApprovalProcedureResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteAccessPolicyRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the access policy.
+      title: DeleteAccessPolicyRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteAccessPolicyResponse:
+      type: object
+      title: DeleteAccessPolicyResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteAppInstanceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the app instance.
+      title: DeleteAppInstanceRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteAppInstanceResponse:
+      type: object
+      title: DeleteAppInstanceResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteAppResourceEntitlementRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the entitlement.
+      title: DeleteAppResourceEntitlementRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteAppResourceEntitlementResponse:
+      type: object
+      title: DeleteAppResourceEntitlementResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteAppResourceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the resource.
+      title: DeleteAppResourceRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteAppResourceResponse:
+      type: object
+      title: DeleteAppResourceResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteAppResourceRoleRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the role.
+      title: DeleteAppResourceRoleRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteAppResourceRoleResponse:
+      type: object
+      title: DeleteAppResourceRoleResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteCustomServiceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the custom service.
+      title: DeleteCustomServiceRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteCustomServiceResponse:
+      type: object
+      title: DeleteCustomServiceResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteGuidanceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the guidance.
+      title: DeleteGuidanceRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteGuidanceResponse:
+      type: object
+      title: DeleteGuidanceResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteWorkflowApprovalProcedureRequest:
+      type: object
+      properties:
+        workflowId:
+          type: string
+          title: workflow_id
+          description: The ID of the workflow.
+        id:
+          type: string
+          title: id
+          description: The ID of the approval procedure.
+      title: DeleteWorkflowApprovalProcedureRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteWorkflowApprovalProcedureResponse:
+      type: object
+      title: DeleteWorkflowApprovalProcedureResponse
+      additionalProperties: false
+    svflow.publicapi.DeleteWorkflowRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the workflow.
+      title: DeleteWorkflowRequest
+      additionalProperties: false
+    svflow.publicapi.DeleteWorkflowResponse:
+      type: object
+      title: DeleteWorkflowResponse
+      additionalProperties: false
+    svflow.publicapi.GetAccessPolicyApprovalProcedureRequest:
+      type: object
+      properties:
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The ID of the access policy.
+        id:
+          type: string
+          title: id
+          description: The ID of the approval procedure.
+      title: GetAccessPolicyApprovalProcedureRequest
+      additionalProperties: false
+    svflow.publicapi.GetAccessPolicyApprovalProcedureResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The approval procedure.
+          $ref: '#/components/schemas/svflow.pubapimodels.AccessPolicyApprovalProcedure'
+      title: GetAccessPolicyApprovalProcedureResponse
+      additionalProperties: false
+    svflow.publicapi.GetAccessPolicyRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the access policy.
+      title: GetAccessPolicyRequest
+      additionalProperties: false
+    svflow.publicapi.GetAccessPolicyResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The access policy.
+          $ref: '#/components/schemas/svflow.pubapimodels.AccessPolicy'
+      title: GetAccessPolicyResponse
+      additionalProperties: false
+    svflow.publicapi.GetAppInstanceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the app instance.
+      title: GetAppInstanceRequest
+      additionalProperties: false
+    svflow.publicapi.GetAppInstanceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The app instance.
+          $ref: '#/components/schemas/svflow.pubapimodels.AppInstance'
+      title: GetAppInstanceResponse
+      additionalProperties: false
+    svflow.publicapi.GetAppResourceEntitlementRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the entitlement.
+      title: GetAppResourceEntitlementRequest
+      additionalProperties: false
+    svflow.publicapi.GetAppResourceEntitlementResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The entitlement.
+          $ref: '#/components/schemas/svflow.pubapimodels.Entitlement'
+      title: GetAppResourceEntitlementResponse
+      additionalProperties: false
+    svflow.publicapi.GetAppResourceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the resource.
+      title: GetAppResourceRequest
+      additionalProperties: false
+    svflow.publicapi.GetAppResourceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The resource.
+          $ref: '#/components/schemas/svflow.pubapimodels.Resource'
+      title: GetAppResourceResponse
+      additionalProperties: false
+    svflow.publicapi.GetAppResourceRoleRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the role.
+      title: GetAppResourceRoleRequest
+      additionalProperties: false
+    svflow.publicapi.GetAppResourceRoleResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The role.
+          $ref: '#/components/schemas/svflow.pubapimodels.Role'
+      title: GetAppResourceRoleResponse
+      additionalProperties: false
+    svflow.publicapi.GetCustomServiceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the custom service.
+      title: GetCustomServiceRequest
+      additionalProperties: false
+    svflow.publicapi.GetCustomServiceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The custom service.
+          $ref: '#/components/schemas/svflow.pubapimodels.CustomService'
+      title: GetCustomServiceResponse
+      additionalProperties: false
+    svflow.publicapi.GetGuidanceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the guidance.
+      title: GetGuidanceRequest
+      additionalProperties: false
+    svflow.publicapi.GetGuidanceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The guidance.
+          $ref: '#/components/schemas/svflow.pubapimodels.Guidance'
+      title: GetGuidanceResponse
+      additionalProperties: false
+    svflow.publicapi.GetTagRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the tag.
+      title: GetTagRequest
+      additionalProperties: false
+    svflow.publicapi.GetTagResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The tag.
+          $ref: '#/components/schemas/svflow.pubapimodels.Tag'
+      title: GetTagResponse
+      additionalProperties: false
+    svflow.publicapi.GetWorkflowApprovalProcedureRequest:
+      type: object
+      properties:
+        workflowId:
+          type: string
+          title: workflow_id
+          description: The ID of the workflow.
+        id:
+          type: string
+          title: id
+          description: The ID of the approval procedure.
+      title: GetWorkflowApprovalProcedureRequest
+      additionalProperties: false
+    svflow.publicapi.GetWorkflowApprovalProcedureResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The approval procedure.
+          $ref: '#/components/schemas/svflow.pubapimodels.WorkflowApprovalProcedure'
+      title: GetWorkflowApprovalProcedureResponse
+      additionalProperties: false
+    svflow.publicapi.GetWorkflowRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the workflow.
+      title: GetWorkflowRequest
+      additionalProperties: false
+    svflow.publicapi.GetWorkflowResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The workflow.
+          $ref: '#/components/schemas/svflow.pubapimodels.Workflow'
+      title: GetWorkflowResponse
+      additionalProperties: false
+    svflow.publicapi.ListAccessPoliciesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListAccessPoliciesRequest
+      additionalProperties: false
+    svflow.publicapi.ListAccessPoliciesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.AccessPolicy'
+          title: data
+          description: The list of access policies.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListAccessPoliciesResponse
+      additionalProperties: false
+    svflow.publicapi.ListAccessPolicyApprovalProceduresRequest:
+      type: object
+      properties:
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The ID of the access policy to list approval procedures for.
+      title: ListAccessPolicyApprovalProceduresRequest
+      additionalProperties: false
+    svflow.publicapi.ListAccessPolicyApprovalProceduresResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.AccessPolicyApprovalProcedure'
+          title: data
+          description: The list of approval procedures (typically 0 or 1).
+      title: ListAccessPolicyApprovalProceduresResponse
+      additionalProperties: false
+    svflow.publicapi.ListAppInstancesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListAppInstancesRequest
+      additionalProperties: false
+    svflow.publicapi.ListAppInstancesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.AppInstance'
+          title: data
+          description: The list of app instances.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListAppInstancesResponse
+      additionalProperties: false
+    svflow.publicapi.ListAppResourceEntitlementsRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: Filter by team ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          nullable: true
+        resourceId:
+          type: string
+          title: resource_id
+          description: Filter by resource ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          nullable: true
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+        appInstanceId:
+          type: string
+          title: app_instance_id
+          description: Filter by app instance ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          nullable: true
+      title: ListAppResourceEntitlementsRequest
+      additionalProperties: false
+    svflow.publicapi.ListAppResourceEntitlementsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Entitlement'
+          title: data
+          description: The list of entitlements.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListAppResourceEntitlementsResponse
+      additionalProperties: false
+    svflow.publicapi.ListAppResourceRolesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: Filter by team ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          nullable: true
+        appInstanceId:
+          type: string
+          title: app_instance_id
+          description: Filter by app instance ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          nullable: true
+        resourceId:
+          type: string
+          title: resource_id
+          description: Filter by resource ID. At least one of team_id, app_instance_id, or resource_id must be provided.
+          nullable: true
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListAppResourceRolesRequest
+      additionalProperties: false
+    svflow.publicapi.ListAppResourceRolesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Role'
+          title: data
+          description: The list of roles.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListAppResourceRolesResponse
+      additionalProperties: false
+    svflow.publicapi.ListAppResourcesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: Filter by team ID. At least one of team_id or app_instance_id must be provided.
+          nullable: true
+        appInstanceId:
+          type: string
+          title: app_instance_id
+          description: Filter by app instance ID. At least one of team_id or app_instance_id must be provided.
+          nullable: true
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListAppResourcesRequest
+      additionalProperties: false
+    svflow.publicapi.ListAppResourcesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Resource'
+          title: data
+          description: The list of resources.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListAppResourcesResponse
+      additionalProperties: false
+    svflow.publicapi.ListCustomServicesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListCustomServicesRequest
+      additionalProperties: false
+    svflow.publicapi.ListCustomServicesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.CustomService'
+          title: data
+          description: The list of custom services.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListCustomServicesResponse
+      additionalProperties: false
+    svflow.publicapi.ListEntitlementsForAppResourceRequest:
+      type: object
+      properties:
+        resourceId:
+          type: string
+          title: resource_id
+          description: The ID of the resource.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListEntitlementsForAppResourceRequest
+      additionalProperties: false
+    svflow.publicapi.ListEntitlementsForAppResourceResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Entitlement'
+          title: data
+          description: The list of entitlements.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListEntitlementsForAppResourceResponse
+      additionalProperties: false
+    svflow.publicapi.ListGuidancesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListGuidancesRequest
+      additionalProperties: false
+    svflow.publicapi.ListGuidancesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Guidance'
+          title: data
+          description: The list of guidances.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListGuidancesResponse
+      additionalProperties: false
+    svflow.publicapi.ListResourcesForAppInstanceRequest:
+      type: object
+      properties:
+        appInstanceId:
+          type: string
+          title: app_instance_id
+          description: The ID of the app instance.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListResourcesForAppInstanceRequest
+      additionalProperties: false
+    svflow.publicapi.ListResourcesForAppInstanceResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Resource'
+          title: data
+          description: The list of resources.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListResourcesForAppInstanceResponse
+      additionalProperties: false
+    svflow.publicapi.ListTagsRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListTagsRequest
+      additionalProperties: false
+    svflow.publicapi.ListTagsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Tag'
+          title: data
+          description: The list of tags.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListTagsResponse
+      additionalProperties: false
+    svflow.publicapi.ListTeamAccessPolicyApprovalProceduresRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+          x-stainless-terraform-configurability: optional
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+          x-stainless-terraform-configurability: computed_optional
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+          x-stainless-terraform-configurability: optional
+      title: ListTeamAccessPolicyApprovalProceduresRequest
+      additionalProperties: false
+    svflow.publicapi.ListTeamAccessPolicyApprovalProceduresResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.AccessPolicyApprovalProcedure'
+          title: data
+          description: The list of access policy approval procedures for the team.
+          x-stainless-terraform-configurability: optional
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+          x-stainless-terraform-configurability: optional
+      title: ListTeamAccessPolicyApprovalProceduresResponse
+      additionalProperties: false
+    svflow.publicapi.ListTeamWorkflowApprovalProceduresRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+          x-stainless-terraform-configurability: optional
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+          x-stainless-terraform-configurability: computed_optional
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+          x-stainless-terraform-configurability: optional
+      title: ListTeamWorkflowApprovalProceduresRequest
+      additionalProperties: false
+    svflow.publicapi.ListTeamWorkflowApprovalProceduresResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.WorkflowApprovalProcedure'
+          title: data
+          description: The list of workflow approval procedures for the team.
+          x-stainless-terraform-configurability: optional
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+          x-stainless-terraform-configurability: optional
+      title: ListTeamWorkflowApprovalProceduresResponse
+      additionalProperties: false
+    svflow.publicapi.ListWorkflowApprovalProceduresRequest:
+      type: object
+      properties:
+        workflowId:
+          type: string
+          title: workflow_id
+          description: The ID of the workflow to list approval procedures for.
+      title: ListWorkflowApprovalProceduresRequest
+      additionalProperties: false
+    svflow.publicapi.ListWorkflowApprovalProceduresResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.WorkflowApprovalProcedure'
+          title: data
+          description: The list of approval procedures (typically 0 or 1).
+      title: ListWorkflowApprovalProceduresResponse
+      additionalProperties: false
+    svflow.publicapi.ListWorkflowsRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        includeTemporary:
+          type: boolean
+          title: include_temporary
+          description: Whether to include temporary workflows (optional, defaults to false).
+          nullable: true
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListWorkflowsRequest
+      additionalProperties: false
+    svflow.publicapi.ListWorkflowsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Workflow'
+          title: data
+          description: The list of workflows.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListWorkflowsResponse
+      additionalProperties: false
+    svflow.publicapi.SearchAppResourceEntitlementsRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: Filter by team ID. Required if app_instance_ids is not provided.
+          nullable: true
+        appInstanceIds:
+          type: array
+          items:
+            type: string
+          title: app_instance_ids
+          description: Filter by app instance IDs.
+        resourceIds:
+          type: array
+          items:
+            type: string
+          title: resource_ids
+          description: Filter by resource IDs.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: SearchAppResourceEntitlementsRequest
+      additionalProperties: false
+    svflow.publicapi.SearchAppResourceEntitlementsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Entitlement'
+          title: data
+          description: The list of entitlements.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: SearchAppResourceEntitlementsResponse
+      additionalProperties: false
+    svflow.publicapi.SearchAppResourceRolesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: Filter by team ID. Required if app_instance_ids is not provided.
+          nullable: true
+        appInstanceIds:
+          type: array
+          items:
+            type: string
+          title: app_instance_ids
+          description: Filter by app instance IDs.
+        resourceIds:
+          type: array
+          items:
+            type: string
+          title: resource_ids
+          description: Filter by resource IDs.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: SearchAppResourceRolesRequest
+      additionalProperties: false
+    svflow.publicapi.SearchAppResourceRolesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Role'
+          title: data
+          description: The list of roles.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: SearchAppResourceRolesResponse
+      additionalProperties: false
+    svflow.publicapi.SearchAppResourcesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: Filter by team ID. Required if app_instance_ids is not provided.
+          nullable: true
+        appInstanceIds:
+          type: array
+          items:
+            type: string
+          title: app_instance_ids
+          description: Filter by app instance IDs.
+        externalIds:
+          type: array
+          items:
+            type: string
+          title: external_ids
+          description: Filter by external IDs. Requires exactly one app_instance_id.
+        resourceIds:
+          type: array
+          items:
+            type: string
+          title: resource_ids
+          description: Filter by specific resource IDs.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 5000, maximum is 5000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: SearchAppResourcesRequest
+      additionalProperties: false
+    svflow.publicapi.SearchAppResourcesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.Resource'
+          title: data
+          description: The list of resources.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: SearchAppResourcesResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateAccessPolicyApprovalProcedureRequest:
+      type: object
+      properties:
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The ID of the access policy.
+        id:
+          type: string
+          title: id
+          description: The ID of the approval procedure.
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+          title: steps
+          description: The approval steps for the procedure.
+      title: UpdateAccessPolicyApprovalProcedureRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateAccessPolicyApprovalProcedureResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated approval procedure.
+          $ref: '#/components/schemas/svflow.pubapimodels.AccessPolicyApprovalProcedure'
+      title: UpdateAccessPolicyApprovalProcedureResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateAccessPolicyRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the access policy.
+        name:
+          type: string
+          title: name
+          description: The name of the access policy.
+        description:
+          type: string
+          title: description
+          description: A description of the access policy.
+        maxAccessMinutes:
+          type: integer
+          title: max_access_minutes
+          format: int32
+          description: The maximum number of minutes that access can be granted for.
+        requireBusinessJustification:
+          type: boolean
+          title: require_business_justification
+          description: Whether a business justification is required when requesting access.
+        recommendedAccessMinutes:
+          type: integer
+          title: recommended_access_minutes
+          format: int32
+          description: The recommended duration in minutes for access requests (optional).
+          nullable: true
+      title: UpdateAccessPolicyRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateAccessPolicyResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated access policy.
+          $ref: '#/components/schemas/svflow.pubapimodels.AccessPolicy'
+      title: UpdateAccessPolicyResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateAppInstanceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the app instance.
+        instanceId:
+          type: string
+          title: instance_id
+          description: The instance ID of the app instance.
+        name:
+          type: string
+          title: name
+          description: The name of the app instance.
+        defaultAccessPolicyId:
+          type: string
+          title: default_access_policy_id
+          description: The default access policy for the app instance (optional).
+          nullable: true
+        accessRequestsEnabled:
+          type: boolean
+          title: access_requests_enabled
+          description: Whether access requests are enabled for the app instance.
+      title: UpdateAppInstanceRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateAppInstanceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated app instance.
+          $ref: '#/components/schemas/svflow.pubapimodels.AppInstance'
+      title: UpdateAppInstanceResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateAppResourceEntitlementInput:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the entitlement to update.
+        name:
+          type: string
+          title: name
+          description: The name of the entitlement.
+        description:
+          type: string
+          title: description
+          description: A description of the entitlement.
+        requestsEnabled:
+          type: boolean
+          title: requests_enabled
+          description: Whether requests are enabled for the entitlement.
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The default access policy for the entitlement (optional).
+          nullable: true
+        provisioningMethod:
+          title: provisioning_method
+          description: Preferred provisioning configuration. Exactly one method should be set.
+          $ref: '#/components/schemas/svflow.pubapimodels.ProvisioningMethod'
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the entitlement in the external system (optional).
+          nullable: true
+        externalData:
+          type: string
+          title: external_data
+          description: Data from the external system as a JSON string (optional).
+          nullable: true
+      title: UpdateAppResourceEntitlementInput
+      additionalProperties: false
+    svflow.publicapi.UpdateAppResourceEntitlementRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the entitlement.
+        name:
+          type: string
+          title: name
+          description: The name of the entitlement.
+        description:
+          type: string
+          title: description
+          description: A description of the entitlement.
+        requestsEnabled:
+          type: boolean
+          title: requests_enabled
+          description: Whether requests are enabled for the entitlement.
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The default access policy for the entitlement (optional).
+          nullable: true
+        provisioningMethod:
+          title: provisioning_method
+          description: Provisioning configuration. Exactly one method should be set.
+          $ref: '#/components/schemas/svflow.pubapimodels.ProvisioningMethod'
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the entitlement in the external system (optional).
+          nullable: true
+        externalData:
+          type: string
+          title: external_data
+          description: Data from the external system as a JSON string (optional).
+          nullable: true
+      title: UpdateAppResourceEntitlementRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateAppResourceEntitlementResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated entitlement.
+          $ref: '#/components/schemas/svflow.pubapimodels.Entitlement'
+      title: UpdateAppResourceEntitlementResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateAppResourceInput:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the resource to update.
+        resourceType:
+          type: string
+          title: resource_type
+          description: The type of the resource.
+        name:
+          type: string
+          title: name
+          description: The name of the resource.
+        description:
+          type: string
+          title: description
+          description: A description of the resource.
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the resource (optional).
+          nullable: true
+      title: UpdateAppResourceInput
+      additionalProperties: false
+    svflow.publicapi.UpdateAppResourceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the resource.
+        resourceType:
+          type: string
+          title: resource_type
+          description: The type of the resource.
+        name:
+          type: string
+          title: name
+          description: The name of the resource.
+        description:
+          type: string
+          title: description
+          description: A description of the resource.
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the resource (optional).
+          nullable: true
+      title: UpdateAppResourceRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateAppResourceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated resource.
+          $ref: '#/components/schemas/svflow.pubapimodels.Resource'
+      title: UpdateAppResourceResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateAppResourceRoleInput:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the role to update.
+        name:
+          type: string
+          title: name
+          description: The name of the role.
+        description:
+          type: string
+          title: description
+          description: A description of the role.
+        requestsEnabled:
+          type: boolean
+          title: requests_enabled
+          description: Whether requests are enabled for the role.
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The default access policy for the role (optional).
+          nullable: true
+        provisioningMethod:
+          title: provisioning_method
+          description: Provisioning configuration. Exactly one method should be set.
+          $ref: '#/components/schemas/svflow.pubapimodels.RoleProvisioningMethod'
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the role in the external system (optional).
+          nullable: true
+        externalData:
+          type: string
+          title: external_data
+          description: Data from the external system as a JSON string (optional).
+          nullable: true
+      title: UpdateAppResourceRoleInput
+      additionalProperties: false
+    svflow.publicapi.UpdateAppResourceRoleRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the role.
+        name:
+          type: string
+          title: name
+          description: The name of the role.
+        description:
+          type: string
+          title: description
+          description: A description of the role.
+        requestsEnabled:
+          type: boolean
+          title: requests_enabled
+          description: Whether requests are enabled for the role.
+        accessPolicyId:
+          type: string
+          title: access_policy_id
+          description: The default access policy for the role (optional).
+          nullable: true
+        provisioningMethod:
+          title: provisioning_method
+          description: Provisioning configuration. Exactly one method should be set.
+          $ref: '#/components/schemas/svflow.pubapimodels.RoleProvisioningMethod'
+        externalId:
+          type: string
+          title: external_id
+          description: The external ID of the role in the external system (optional).
+          nullable: true
+        externalData:
+          type: string
+          title: external_data
+          description: Data from the external system as a JSON string (optional).
+          nullable: true
+      title: UpdateAppResourceRoleRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateAppResourceRoleResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated role.
+          $ref: '#/components/schemas/svflow.pubapimodels.Role'
+      title: UpdateAppResourceRoleResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateCustomServiceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the custom service.
+        name:
+          type: string
+          title: name
+          description: The name of the custom service.
+        domain:
+          type: string
+          title: domain
+          description: The domain for branding/logo lookup.
+      title: UpdateCustomServiceRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateCustomServiceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated custom service.
+          $ref: '#/components/schemas/svflow.pubapimodels.CustomService'
+      title: UpdateCustomServiceResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateGuidanceRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the guidance.
+        name:
+          type: string
+          title: name
+          description: The name of the guidance.
+        description:
+          type: string
+          title: description
+          description: A description of the guidance.
+        content:
+          type: string
+          title: content
+          description: The content of the guidance.
+        shouldAlwaysUse:
+          type: boolean
+          title: should_always_use
+          description: Whether this guidance should always be used (optional).
+          nullable: true
+      title: UpdateGuidanceRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateGuidanceResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated guidance.
+          $ref: '#/components/schemas/svflow.pubapimodels.Guidance'
+      title: UpdateGuidanceResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateWorkflowApprovalProcedureRequest:
+      type: object
+      properties:
+        workflowId:
+          type: string
+          title: workflow_id
+          description: The ID of the workflow.
+        id:
+          type: string
+          title: id
+          description: The ID of the approval procedure.
+        steps:
+          type: array
+          items:
+            $ref: '#/components/schemas/svflow.pubapimodels.ApprovalStep'
+          title: steps
+          description: The approval steps for the procedure.
+      title: UpdateWorkflowApprovalProcedureRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateWorkflowApprovalProcedureResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated approval procedure.
+          $ref: '#/components/schemas/svflow.pubapimodels.WorkflowApprovalProcedure'
+      title: UpdateWorkflowApprovalProcedureResponse
+      additionalProperties: false
+    svflow.publicapi.UpdateWorkflowRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the workflow.
+        name:
+          type: string
+          title: name
+          description: The name of the workflow.
+        description:
+          type: string
+          title: description
+          description: A description of the workflow.
+        type:
+          title: type
+          description: The type of the workflow.
+          $ref: '#/components/schemas/svflow.pubapimodels.WorkflowType'
+        executionScope:
+          title: execution_scope
+          description: The execution scope of the workflow.
+          $ref: '#/components/schemas/svflow.pubapimodels.WorkflowExecutionScope'
+        requireFormConfirmation:
+          type: boolean
+          title: require_form_confirmation
+          description: Whether the workflow requires form confirmation.
+        isTemporary:
+          type: boolean
+          title: is_temporary
+          description: Whether the workflow is temporary.
+        content:
+          type: string
+          title: content
+          description: The content/code of the workflow.
+        parameters:
+          type: string
+          title: parameters
+          description: The parameters schema of the workflow (JSON).
+      title: UpdateWorkflowRequest
+      additionalProperties: false
+    svflow.publicapi.UpdateWorkflowResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated workflow.
+          $ref: '#/components/schemas/svflow.pubapimodels.Workflow'
+      title: UpdateWorkflowResponse
+      additionalProperties: false
+    svhelp.pubapimodels.ChannelSyncTarget:
+      type: object
+      oneOf:
+        - properties:
+            email:
+              title: email
+              $ref: '#/components/schemas/svhelp.pubapimodels.EmailTarget'
+          title: email
+          required:
+            - email
+        - properties:
+            slackDm:
+              title: slack_dm
+              $ref: '#/components/schemas/svhelp.pubapimodels.SlackDMTarget'
+          title: slack_dm
+          required:
+            - slackDm
+      title: ChannelSyncTarget
+      additionalProperties: false
+    svhelp.pubapimodels.ChannelTarget:
+      type: object
+      oneOf:
+        - properties:
+            email:
+              title: email
+              $ref: '#/components/schemas/svhelp.pubapimodels.EmailChannelTarget'
+          title: email
+          required:
+            - email
+        - properties:
+            slackDm:
+              title: slack_dm
+              $ref: '#/components/schemas/svhelp.pubapimodels.SlackDMChannelTarget'
+          title: slack_dm
+          required:
+            - slackDm
+        - properties:
+            ticketSource:
+              title: ticket_source
+              $ref: '#/components/schemas/svhelp.pubapimodels.TicketSourceChannelTarget'
+          title: ticket_source
+          required:
+            - ticketSource
+      title: ChannelTarget
+      additionalProperties: false
+      description: |-
+        Unified channel target that works across all syncing scenarios.
+         This is used by SyncTicketToChannel and ConnectTicketToExternalTicket endpoints.
+    svhelp.pubapimodels.EmailChannelTarget:
+      type: object
+      properties:
+        targetUserType:
+          title: target_user_type
+          description: Which user to send the email to
+          $ref: '#/components/schemas/svhelp.pubapimodels.ChannelSyncTargetUserType'
+      title: EmailChannelTarget
+      additionalProperties: false
+      description: For Email channels - uses team email config (no integration needed)
+    svhelp.pubapimodels.EmailTarget:
+      type: object
+      properties:
+        targetUserType:
+          title: target_user_type
+          $ref: '#/components/schemas/svhelp.pubapimodels.ChannelSyncTargetUserType'
+      title: EmailTarget
+      additionalProperties: false
+    svhelp.pubapimodels.ExternalMessage:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the external message in Serval's system
+        externalMessageId:
+          type: string
+          title: external_message_id
+          description: The ID of the external message in the external system
+        messageId:
+          type: string
+          title: message_id
+          description: The ID of the Serval message this external message is linked to
+        sourceType:
+          title: source_type
+          description: The type of external system (Slack, Jira, Email, etc.)
+          $ref: '#/components/schemas/svhelp.pubapimodels.ExternalMessageSourceType'
+        sourceId:
+          type: string
+          title: source_id
+          description: The ID of the source/integration in Serval
+        isOrigin:
+          type: boolean
+          title: is_origin
+          description: |-
+            Whether this external message is the origin source of the Serval message
+             True if the Serval message was created from this external message
+        createdAt:
+          title: created_at
+          description: Timestamp when the external message link was created
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        updatedAt:
+          title: updated_at
+          description: Timestamp when the external message link was last updated
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+      title: ExternalMessage
+      additionalProperties: false
+      description: ExternalMessage represents a Serval message's connection to an external system
+    svhelp.pubapimodels.ExternalTicket:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the external ticket in Serval's system
+        externalTicketId:
+          type: string
+          title: external_ticket_id
+          description: The ID of the external ticket in the external system (e.g., "PROJ-123" for Jira)
+        ticketId:
+          type: string
+          title: ticket_id
+          description: The ID of the Serval ticket this external ticket is linked to
+        sourceType:
+          title: source_type
+          description: The type of external system (Jira, Linear, ServiceNow, etc.)
+          $ref: '#/components/schemas/svhelp.pubapimodels.ExternalTicketSourceType'
+        sourceId:
+          type: string
+          title: source_id
+          description: The ID of the source/integration in Serval (connected service ID)
+        isOrigin:
+          type: boolean
+          title: is_origin
+          description: |-
+            Whether this external ticket is the origin source of the Serval ticket
+             True if the Serval ticket was created from this external ticket
+        createdAt:
+          title: created_at
+          description: Timestamp when the external ticket link was created
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        updatedAt:
+          title: updated_at
+          description: Timestamp when the external ticket link was last updated
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        url:
+          type: string
+          title: url
+          description: URL to view the external ticket in the external system
+          nullable: true
+      title: ExternalTicket
+      additionalProperties: false
+      description: ExternalTicket represents a Serval ticket's connection to an external system
+    svhelp.pubapimodels.Label:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the label.
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team that the label belongs to.
+        name:
+          type: string
+          title: name
+          description: The name of the label.
+        description:
+          type: string
+          title: description
+          description: The description of the label.
+      title: Label
+      additionalProperties: false
+    svhelp.pubapimodels.Priority:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the priority.
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team that the priority belongs to.
+        priority:
+          type: string
+          title: priority
+          description: The priority level (NONE, LOW, MEDIUM, HIGH, URGENT, etc.).
+        description:
+          type: string
+          title: description
+          description: The description of the priority.
+      title: Priority
+      additionalProperties: false
+    svhelp.pubapimodels.SlackDMChannelTarget:
+      type: object
+      properties:
+        integrationId:
+          type: string
+          title: integration_id
+          description: Integration ID that identifies the Slack app instance
+        targetUserType:
+          title: target_user_type
+          description: Which user to send the DM to
+          $ref: '#/components/schemas/svhelp.pubapimodels.ChannelSyncTargetUserType'
+      title: SlackDMChannelTarget
+      additionalProperties: false
+      description: For Slack DM channels - need to specify which user to sync to
+    svhelp.pubapimodels.SlackDMTarget:
+      type: object
+      properties:
+        targetUserType:
+          title: target_user_type
+          $ref: '#/components/schemas/svhelp.pubapimodels.ChannelSyncTargetUserType'
+      title: SlackDMTarget
+      additionalProperties: false
+    svhelp.pubapimodels.Status:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the status.
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team that the status belongs to.
+        statusGroup:
+          title: status_group
+          description: The status group.
+          $ref: '#/components/schemas/svhelp.models.TicketStatusGroup'
+        name:
+          type: string
+          title: name
+          description: The name of the status.
+        description:
+          type: string
+          title: description
+          description: The description of the status.
+        isDefault:
+          type: boolean
+          title: is_default
+          description: Whether this is the default status for the team.
+      title: Status
+      additionalProperties: false
+    svhelp.pubapimodels.Ticket:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the Serval ticket.
+        friendlyIdentifier:
+          type: string
+          title: friendly_identifier
+          description: "A friendly identifier for the ticket. This is a unique identifier for the ticket that is displayed to the user. It is a combination \n of the team prefix (configured in Settings > Organization Settings > Teams) and the ticket number.\n Example: For the Acme team's 10th ticket, the friendly identifier is \"ACM-10\"."
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team that the ticket belongs to.
+        name:
+          type: string
+          title: name
+          description: A name or title for the ticket.
+        description:
+          type: string
+          title: description
+          description: A description of the ticket.
+        createdAt:
+          title: created_at
+          description: "Timestamp indicating when the ticket was created. Will be in RFC 3339 format \n (e.g., \"2017-01-15T01:30:15.01Z\")."
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        completedAt:
+          title: completed_at
+          description: "Timestamp indicating when the ticket was completed. Will be in RFC 3339 format \n (e.g., \"2017-01-15T01:30:15.01Z\")."
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        escalatedAt:
+          title: escalated_at
+          description: "Timestamp indicating when the ticket was escalated. Will be in RFC 3339 format \n (e.g., \"2017-01-15T01:30:15.01Z\")."
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        createdByUserId:
+          type: string
+          title: created_by_user_id
+          description: The ID of the user who created the ticket.
+        assignedToUserId:
+          type: string
+          title: assigned_to_user_id
+          description: The ID of the user who is assigned to the ticket. Optional if the ticket is not assigned to a user.
+          nullable: true
+        requesterUserId:
+          type: string
+          title: requester_user_id
+          description: The ID of the user this ticket was created on behalf of (the requester).
+        statusId:
+          type: string
+          title: status_id
+          description: The ID of the status option for the ticket.
+        escalationLevel:
+          title: escalation_level
+          description: The escalation level of the ticket.
+          $ref: '#/components/schemas/svhelp.models.TicketEscalationLevel'
+        priorityId:
+          type: string
+          title: priority_id
+          description: The ID of the priority option for the ticket.
+        slaStartedAt:
+          title: sla_started_at
+          description: "Timestamp indicating when the SLA started. Will be in RFC 3339 format \n (e.g., \"2017-01-15T01:30:15.01Z\")."
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        slaBreachesAt:
+          title: sla_breaches_at
+          description: "Timestamp indicating when the SLA was breached. Will be in RFC 3339 format \n (e.g., \"2017-01-15T01:30:15.01Z\")."
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        labelIds:
+          type: array
+          items:
+            type: string
+          title: label_ids
+          description: List of label IDs for the ticket.
+        type:
+          title: type
+          description: 'The type of ticket. Possible values: TICKET_TYPE_REQUEST, TICKET_TYPE_TASK, TICKET_TYPE_INCIDENT.'
+          $ref: '#/components/schemas/svhelp.models.TicketType'
+        relationshipIds:
+          type: array
+          items:
+            type: string
+          title: relationship_ids
+          description: List of relationship IDs for this ticket. Use ListTicketRelationships to get full details.
+      title: Ticket
+      additionalProperties: false
+    svhelp.pubapimodels.TicketRelationship:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the ticket relationship
+        ticketId:
+          type: string
+          title: ticket_id
+          description: The ID of the first ticket in the relationship
+        relatedTicketId:
+          type: string
+          title: related_ticket_id
+          description: The ID of the related ticket
+        relationshipType:
+          title: relationship_type
+          description: The type of relationship between the tickets
+          $ref: '#/components/schemas/svhelp.pubapimodels.TicketRelationshipType'
+      title: TicketRelationship
+      additionalProperties: false
+      description: TicketRelationship represents a relationship between two tickets
+    svhelp.pubapimodels.TicketSourceChannelTarget:
+      type: object
+      properties:
+        ticketSourceId:
+          type: string
+          title: ticket_source_id
+          description: |-
+            The ticket source ID from svflow - identifies which external system
+             Deprecated: Use integration_id instead
+        integrationId:
+          type: string
+          title: integration_id
+          description: The integration ID - identifies which external system/integration to sync to
+      title: TicketSourceChannelTarget
+      additionalProperties: false
+      description: For ticket source channels (Jira, ServiceNow, Linear, Zendesk, Freshservice, etc.)
+    svhelp.pubapimodels.TicketSubscriber:
+      type: object
+      properties:
+        userId:
+          type: string
+          title: user_id
+          description: The ID of the user who is subscribed to the ticket.
+        canUnsubscribe:
+          type: boolean
+          title: can_unsubscribe
+          description: "Whether the user can unsubscribe from the ticket. \n False for users who are automatically subscribed (e.g., requester, assignee, message authors)."
+      title: TicketSubscriber
+      additionalProperties: false
+    svhelp.publicapi.ConnectTicketToExternalTicketRequest:
+      type: object
+      properties:
+        ticketId:
+          type: string
+          title: ticket_id
+          description: The Serval ticket ID to connect
+        channelTarget:
+          title: channel_target
+          description: The channel containing the external ticket
+          $ref: '#/components/schemas/svhelp.pubapimodels.ChannelTarget'
+        externalTicketId:
+          type: string
+          title: external_ticket_id
+          description: |-
+            The external ticket ID (which depends on the channel type)
+             but should be a globally unique identifier for the external ticket
+        externalTicketData:
+          title: external_ticket_data
+          description: |-
+            Optional: Raw external ticket data/metadata to store with the connection.
+             This should be the JSON-serialized external ticket object from the external system.
+             For ServiceNow, this should be the RequestedItem or Incident object.
+             If not provided, external links may not display correctly.
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Struct'
+        externalTicketSubtype:
+          type: string
+          title: external_ticket_subtype
+          description: |-
+            Optional: Subtype of the external ticket within the integration.
+             For ServiceNow, use "incident" or "requested_item" to specify the type.
+             This determines which sync handler is used for ongoing synchronization.
+          nullable: true
+      title: ConnectTicketToExternalTicketRequest
+      additionalProperties: false
+    svhelp.publicapi.ConnectTicketToExternalTicketResponse:
+      type: object
+      title: ConnectTicketToExternalTicketResponse
+      additionalProperties: false
+    svhelp.publicapi.CreateTicketRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+        name:
+          type: string
+          title: name
+        description:
+          type: string
+          title: description
+        createdByUserId:
+          type: string
+          title: created_by_user_id
+        createdAt:
+          title: created_at
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        assignedToUserId:
+          type: string
+          title: assigned_to_user_id
+          nullable: true
+        parentTicketId:
+          type: string
+          title: parent_ticket_id
+          nullable: true
+        createdByWorkflowRunId:
+          type: string
+          title: created_by_workflow_run_id
+          description: '@internal - set by the worker but not included in docs to avoid confusion.'
+          nullable: true
+        channelSyncTargets:
+          type: array
+          items:
+            $ref: '#/components/schemas/svhelp.pubapimodels.ChannelSyncTarget'
+          title: channel_sync_targets
+          description: |-
+            Note that these are ADDITIONAL sync targets. There may be some "default" sync
+             targets for the team (e.g. ServiceNow, JSM etc).
+        aiActive:
+          type: boolean
+          title: ai_active
+          description: |-
+            Optional. Whether AI is active for this ticket. Defaults to false.
+             When true, users can chat with Serval AI for assistance on this ticket.
+          nullable: true
+        type:
+          title: type
+          description: |-
+            Optional. The type of ticket to create. Defaults to REQUEST.
+             If parent_ticket_id is set, this must be TASK (or omitted, in which case TASK is used).
+          nullable: true
+          $ref: '#/components/schemas/svhelp.models.TicketType'
+      title: CreateTicketRequest
+      additionalProperties: false
+    svhelp.publicapi.CreateTicketResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svhelp.pubapimodels.Ticket'
+      title: CreateTicketResponse
+      additionalProperties: false
+    svhelp.publicapi.CreateTicketSubscribersRequest:
+      type: object
+      properties:
+        ticketId:
+          type: string
+          title: ticket_id
+        userIds:
+          type: array
+          items:
+            type: string
+          title: user_ids
+      title: CreateTicketSubscribersRequest
+      additionalProperties: false
+    svhelp.publicapi.CreateTicketSubscribersResponse:
+      type: object
+      title: CreateTicketSubscribersResponse
+      additionalProperties: false
+    svhelp.publicapi.DeleteTicketSubscribersRequest:
+      type: object
+      properties:
+        ticketId:
+          type: string
+          title: ticket_id
+        userId:
+          type: string
+          title: user_id
+      title: DeleteTicketSubscribersRequest
+      additionalProperties: false
+    svhelp.publicapi.DeleteTicketSubscribersResponse:
+      type: object
+      title: DeleteTicketSubscribersResponse
+      additionalProperties: false
+    svhelp.publicapi.DisconnectTicketFromExternalTicketRequest:
+      type: object
+      properties:
+        ticketId:
+          type: string
+          title: ticket_id
+          description: The Serval ticket ID to disconnect from
+        sourceId:
+          type: string
+          title: source_id
+          description: |-
+            The source ID (connected service ID or integration ID) to disconnect
+             This identifies which external system/channel to stop syncing with
+      title: DisconnectTicketFromExternalTicketRequest
+      additionalProperties: false
+    svhelp.publicapi.DisconnectTicketFromExternalTicketResponse:
+      type: object
+      title: DisconnectTicketFromExternalTicketResponse
+      additionalProperties: false
+    svhelp.publicapi.GetTicketRelationshipRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the ticket relationship
+      title: GetTicketRelationshipRequest
+      additionalProperties: false
+    svhelp.publicapi.GetTicketRelationshipResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svhelp.pubapimodels.TicketRelationship'
+      title: GetTicketRelationshipResponse
+      additionalProperties: false
+    svhelp.publicapi.GetTicketRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: GetTicketRequest
+      additionalProperties: false
+    svhelp.publicapi.GetTicketResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svhelp.pubapimodels.Ticket'
+      title: GetTicketResponse
+      additionalProperties: false
+    svhelp.publicapi.ListLabelsRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListLabelsRequest
+      additionalProperties: false
+    svhelp.publicapi.ListLabelsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svhelp.pubapimodels.Label'
+          title: data
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListLabelsResponse
+      additionalProperties: false
+    svhelp.publicapi.ListPrioritiesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListPrioritiesRequest
+      additionalProperties: false
+    svhelp.publicapi.ListPrioritiesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svhelp.pubapimodels.Priority'
+          title: data
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListPrioritiesResponse
+      additionalProperties: false
+    svhelp.publicapi.ListStatusesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListStatusesRequest
+      additionalProperties: false
+    svhelp.publicapi.ListStatusesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svhelp.pubapimodels.Status'
+          title: data
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListStatusesResponse
+      additionalProperties: false
+    svhelp.publicapi.ListTicketExternalMessagesRequest:
+      type: object
+      properties:
+        ticketId:
+          type: string
+          title: ticket_id
+          description: The ID of the Serval ticket to list external messages for
+      title: ListTicketExternalMessagesRequest
+      additionalProperties: false
+    svhelp.publicapi.ListTicketExternalMessagesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svhelp.pubapimodels.ExternalMessage'
+          title: data
+      title: ListTicketExternalMessagesResponse
+      additionalProperties: false
+    svhelp.publicapi.ListTicketExternalTicketsRequest:
+      type: object
+      properties:
+        ticketId:
+          type: string
+          title: ticket_id
+          description: The ID of the Serval ticket to list external tickets for
+      title: ListTicketExternalTicketsRequest
+      additionalProperties: false
+    svhelp.publicapi.ListTicketExternalTicketsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svhelp.pubapimodels.ExternalTicket'
+          title: data
+      title: ListTicketExternalTicketsResponse
+      additionalProperties: false
+    svhelp.publicapi.ListTicketSubscribersRequest:
+      type: object
+      properties:
+        ticketId:
+          type: string
+          title: ticket_id
+      title: ListTicketSubscribersRequest
+      additionalProperties: false
+    svhelp.publicapi.ListTicketSubscribersResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svhelp.pubapimodels.TicketSubscriber'
+          title: data
+      title: ListTicketSubscribersResponse
+      additionalProperties: false
+    svhelp.publicapi.ListTicketsRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+        startTime:
+          title: start_time
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        endTime:
+          title: end_time
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListTicketsRequest
+      additionalProperties: false
+    svhelp.publicapi.ListTicketsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svhelp.pubapimodels.Ticket'
+          title: data
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListTicketsResponse
+      additionalProperties: false
+    svhelp.publicapi.SyncTicketToChannelRequest:
+      type: object
+      properties:
+        ticketId:
+          type: string
+          title: ticket_id
+          description: The Serval ticket ID to sync
+        channelTarget:
+          title: channel_target
+          description: The channel to sync to (creates external ticket and establishes ongoing sync)
+          $ref: '#/components/schemas/svhelp.pubapimodels.ChannelTarget'
+      title: SyncTicketToChannelRequest
+      additionalProperties: false
+    svhelp.publicapi.SyncTicketToChannelResponse:
+      type: object
+      title: SyncTicketToChannelResponse
+      additionalProperties: false
+    svhelp.publicapi.UpdateTicketRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        name:
+          type: string
+          title: name
+          nullable: true
+        description:
+          type: string
+          title: description
+          nullable: true
+        statusId:
+          type: string
+          title: status_id
+          nullable: true
+        priorityId:
+          type: string
+          title: priority_id
+          nullable: true
+        assignedToUserId:
+          type: string
+          title: assigned_to_user_id
+          nullable: true
+        labelIds:
+          type: array
+          items:
+            type: string
+          title: label_ids
+        slaStartedAt:
+          title: sla_started_at
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        slaBreachesAt:
+          title: sla_breaches_at
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        escalationLevel:
+          title: escalation_level
+          nullable: true
+          $ref: '#/components/schemas/svhelp.models.TicketEscalationLevel'
+        requesterUserId:
+          type: string
+          title: requester_user_id
+          nullable: true
+      title: UpdateTicketRequest
+      additionalProperties: false
+    svhelp.publicapi.UpdateTicketResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          $ref: '#/components/schemas/svhelp.pubapimodels.Ticket'
+      title: UpdateTicketResponse
+      additionalProperties: false
+    svlog.events.AccessDeprovisionedEvent:
+      type: object
+      properties:
+        accessRequest:
+          title: access_request
+          $ref: '#/components/schemas/svlog.events.AccessRequest'
+        entitlement:
+          title: entitlement
+          $ref: '#/components/schemas/svlog.events.Entitlement'
+        resource:
+          title: resource
+          $ref: '#/components/schemas/svlog.events.Resource'
+        user:
+          title: user
+          description: The user whose access was removed
+          $ref: '#/components/schemas/svlog.events.User'
+        reason:
+          type: string
+          title: reason
+          description: Optional free-form reason (e.g., "expired", "revoked")
+        ticket:
+          title: ticket
+          $ref: '#/components/schemas/svlog.events.Ticket'
+      title: AccessDeprovisionedEvent
+      additionalProperties: false
+      description: Emitted when a user's access has been deprovisioned for an entitlement
+    svlog.events.AccessPolicy:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        displayName:
+          type: string
+          title: display_name
+      title: AccessPolicy
+      additionalProperties: false
+    svlog.events.AccessPolicyCreatedEvent:
+      type: object
+      properties:
+        accessPolicy:
+          title: access_policy
+          $ref: '#/components/schemas/svlog.events.AccessPolicy'
+      title: AccessPolicyCreatedEvent
+      additionalProperties: false
+    svlog.events.AccessPolicyDeletedEvent:
+      type: object
+      properties:
+        accessPolicy:
+          title: access_policy
+          $ref: '#/components/schemas/svlog.events.AccessPolicy'
+      title: AccessPolicyDeletedEvent
+      additionalProperties: false
+    svlog.events.AccessPolicyUpdatedEvent:
+      type: object
+      properties:
+        accessPolicy:
+          title: access_policy
+          $ref: '#/components/schemas/svlog.events.AccessPolicy'
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/svlog.events.FieldChange'
+          title: changes
+          description: What actually changed
+      title: AccessPolicyUpdatedEvent
+      additionalProperties: false
+    svlog.events.AccessProvisionedEvent:
+      type: object
+      properties:
+        accessRequest:
+          title: access_request
+          $ref: '#/components/schemas/svlog.events.AccessRequest'
+        entitlement:
+          title: entitlement
+          $ref: '#/components/schemas/svlog.events.Entitlement'
+        resource:
+          title: resource
+          $ref: '#/components/schemas/svlog.events.Resource'
+        user:
+          title: user
+          description: The user who now has access
+          $ref: '#/components/schemas/svlog.events.User'
+        ticket:
+          title: ticket
+          $ref: '#/components/schemas/svlog.events.Ticket'
+      title: AccessProvisionedEvent
+      additionalProperties: false
+      description: Emitted when a user's access has been provisioned for an entitlement
+    svlog.events.AccessRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: AccessRequest
+      additionalProperties: false
+    svlog.events.AuditLogEvent:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        teamId:
+          type: string
+          title: team_id
+          description: Not all events are team-specific (though most are)
+          nullable: true
+        timestamp:
+          title: timestamp
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        actor:
+          title: actor
+          $ref: '#/components/schemas/svauth.models.Actor'
+        context:
+          title: context
+          $ref: '#/components/schemas/svlog.events.Context'
+        eventType:
+          title: event_type
+          $ref: '#/components/schemas/svlog.events.EventType'
+      title: AuditLogEvent
+      additionalProperties: false
+      description: |-
+        AuditLogEvent is the schema for events received in the audit log event queue from
+         other services
+         These are the events that will be processed by svlog
+    svlog.events.BoolFieldChange:
+      type: object
+      properties:
+        oldValue:
+          type: boolean
+          title: old_value
+        newValue:
+          type: boolean
+          title: new_value
+      title: BoolFieldChange
+      additionalProperties: false
+    svlog.events.Context:
+      type: object
+      properties:
+        ipAddress:
+          type: string
+          title: ip_address
+        userAgent:
+          type: string
+          title: user_agent
+      title: Context
+      additionalProperties: false
+    svlog.events.Entitlement:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        displayName:
+          type: string
+          title: display_name
+      title: Entitlement
+      additionalProperties: false
+    svlog.events.EventType:
+      type: object
+      oneOf:
+        - properties:
+            accessDeprovisioned:
+              title: access_deprovisioned
+              $ref: '#/components/schemas/svlog.events.AccessDeprovisionedEvent'
+          title: access_deprovisioned
+          required:
+            - accessDeprovisioned
+        - properties:
+            accessPolicyCreated:
+              title: access_policy_created
+              $ref: '#/components/schemas/svlog.events.AccessPolicyCreatedEvent'
+          title: access_policy_created
+          required:
+            - accessPolicyCreated
+        - properties:
+            accessPolicyDeleted:
+              title: access_policy_deleted
+              $ref: '#/components/schemas/svlog.events.AccessPolicyDeletedEvent'
+          title: access_policy_deleted
+          required:
+            - accessPolicyDeleted
+        - properties:
+            accessPolicyUpdated:
+              title: access_policy_updated
+              $ref: '#/components/schemas/svlog.events.AccessPolicyUpdatedEvent'
+          title: access_policy_updated
+          required:
+            - accessPolicyUpdated
+        - properties:
+            accessProvisioned:
+              title: access_provisioned
+              description: Access lifecycle events
+              $ref: '#/components/schemas/svlog.events.AccessProvisionedEvent'
+          title: access_provisioned
+          required:
+            - accessProvisioned
+        - properties:
+            guidanceCreated:
+              title: guidance_created
+              $ref: '#/components/schemas/svlog.events.GuidanceCreatedEvent'
+          title: guidance_created
+          required:
+            - guidanceCreated
+        - properties:
+            guidanceDeleted:
+              title: guidance_deleted
+              $ref: '#/components/schemas/svlog.events.GuidanceDeletedEvent'
+          title: guidance_deleted
+          required:
+            - guidanceDeleted
+        - properties:
+            guidanceDeployed:
+              title: guidance_deployed
+              $ref: '#/components/schemas/svlog.events.GuidanceDeployedEvent'
+          title: guidance_deployed
+          required:
+            - guidanceDeployed
+        - properties:
+            guidanceUpdated:
+              title: guidance_updated
+              $ref: '#/components/schemas/svlog.events.GuidanceUpdatedEvent'
+          title: guidance_updated
+          required:
+            - guidanceUpdated
+        - properties:
+            userAddedToTeam:
+              title: user_added_to_team
+              $ref: '#/components/schemas/svlog.events.UserAddedToTeamEvent'
+          title: user_added_to_team
+          required:
+            - userAddedToTeam
+        - properties:
+            userInvited:
+              title: user_invited
+              $ref: '#/components/schemas/svlog.events.UserInvitedEvent'
+          title: user_invited
+          required:
+            - userInvited
+        - properties:
+            userOrganizationRoleChanged:
+              title: user_organization_role_changed
+              $ref: '#/components/schemas/svlog.events.UserOrganizationRoleChangedEvent'
+          title: user_organization_role_changed
+          required:
+            - userOrganizationRoleChanged
+        - properties:
+            userRemovedFromTeam:
+              title: user_removed_from_team
+              $ref: '#/components/schemas/svlog.events.UserRemovedFromTeamEvent'
+          title: user_removed_from_team
+          required:
+            - userRemovedFromTeam
+        - properties:
+            userTeamRoleChanged:
+              title: user_team_role_changed
+              $ref: '#/components/schemas/svlog.events.UserTeamRoleChangedEvent'
+          title: user_team_role_changed
+          required:
+            - userTeamRoleChanged
+        - properties:
+            workflowCreated:
+              title: workflow_created
+              $ref: '#/components/schemas/svlog.events.WorkflowCreatedEvent'
+          title: workflow_created
+          required:
+            - workflowCreated
+        - properties:
+            workflowDeleted:
+              title: workflow_deleted
+              $ref: '#/components/schemas/svlog.events.WorkflowDeletedEvent'
+          title: workflow_deleted
+          required:
+            - workflowDeleted
+        - properties:
+            workflowPublished:
+              title: workflow_published
+              $ref: '#/components/schemas/svlog.events.WorkflowPublishedEvent'
+          title: workflow_published
+          required:
+            - workflowPublished
+        - properties:
+            workflowRunRequested:
+              title: workflow_run_requested
+              $ref: '#/components/schemas/svlog.events.WorkflowRunRequestedEvent'
+          title: workflow_run_requested
+          required:
+            - workflowRunRequested
+        - properties:
+            workflowRunStarted:
+              title: workflow_run_started
+              $ref: '#/components/schemas/svlog.events.WorkflowRunStartedEvent'
+          title: workflow_run_started
+          required:
+            - workflowRunStarted
+        - properties:
+            workflowUpdated:
+              title: workflow_updated
+              $ref: '#/components/schemas/svlog.events.WorkflowUpdatedEvent'
+          title: workflow_updated
+          required:
+            - workflowUpdated
+      title: EventType
+      additionalProperties: false
+    svlog.events.FieldChange:
+      type: object
+      oneOf:
+        - properties:
+            boolChange:
+              title: bool_change
+              $ref: '#/components/schemas/svlog.events.BoolFieldChange'
+          title: bool_change
+          required:
+            - boolChange
+        - properties:
+            jsonChange:
+              title: json_change
+              $ref: '#/components/schemas/svlog.events.JsonFieldChange'
+          title: json_change
+          required:
+            - jsonChange
+        - properties:
+            numberChange:
+              title: number_change
+              $ref: '#/components/schemas/svlog.events.NumberFieldChange'
+          title: number_change
+          required:
+            - numberChange
+        - properties:
+            stringChange:
+              title: string_change
+              $ref: '#/components/schemas/svlog.events.StringFieldChange'
+          title: string_change
+          required:
+            - stringChange
+        - properties:
+            timestampChange:
+              title: timestamp_change
+              $ref: '#/components/schemas/svlog.events.TimestampFieldChange'
+          title: timestamp_change
+          required:
+            - timestampChange
+      properties:
+        fieldName:
+          type: string
+          title: field_name
+          description: e.g., "name", "description", "enabled"
+      title: FieldChange
+      additionalProperties: false
+      description: |-
+        Generic field change tracking - We keep this generic
+         to minimize the amount of schema we have to keep in sync
+         just to track field changes.
+    svlog.events.Guidance:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        displayName:
+          type: string
+          title: display_name
+          description: Should generally include a name where possible as makes it easier to identify the object on export to SIEM without complex hydration
+      title: Guidance
+      additionalProperties: false
+    svlog.events.GuidanceCreatedEvent:
+      type: object
+      properties:
+        guidance:
+          title: guidance
+          $ref: '#/components/schemas/svlog.events.Guidance'
+      title: GuidanceCreatedEvent
+      additionalProperties: false
+    svlog.events.GuidanceDeletedEvent:
+      type: object
+      properties:
+        guidance:
+          title: guidance
+          $ref: '#/components/schemas/svlog.events.Guidance'
+      title: GuidanceDeletedEvent
+      additionalProperties: false
+    svlog.events.GuidanceDeployedEvent:
+      type: object
+      properties:
+        guidance:
+          title: guidance
+          $ref: '#/components/schemas/svlog.events.Guidance'
+        previousVersion:
+          title: previous_version
+          description: null if first deployed
+          nullable: true
+          $ref: '#/components/schemas/svlog.events.GuidanceVersion'
+        deployedVersion:
+          title: deployed_version
+          $ref: '#/components/schemas/svlog.events.GuidanceVersion'
+      title: GuidanceDeployedEvent
+      additionalProperties: false
+    svlog.events.GuidanceUpdatedEvent:
+      type: object
+      properties:
+        guidance:
+          title: guidance
+          $ref: '#/components/schemas/svlog.events.Guidance'
+        version:
+          title: version
+          $ref: '#/components/schemas/svlog.events.GuidanceVersion'
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/svlog.events.FieldChange'
+          title: changes
+          description: What actually changed
+      title: GuidanceUpdatedEvent
+      additionalProperties: false
+    svlog.events.GuidanceVersion:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: This is the version ID, not the guidance ID
+        displayName:
+          type: string
+          title: display_name
+        guidanceId:
+          type: string
+          title: guidance_id
+        versionNumber:
+          type: integer
+          title: version_number
+          format: int32
+      title: GuidanceVersion
+      additionalProperties: false
+    svlog.events.JsonFieldChange:
+      type: object
+      properties:
+        oldValue:
+          type: string
+          title: old_value
+          description: JSON string
+        newValue:
+          type: string
+          title: new_value
+          description: JSON string
+      title: JsonFieldChange
+      additionalProperties: false
+    svlog.events.NumberFieldChange:
+      type: object
+      properties:
+        oldValue:
+          type: number
+          title: old_value
+          format: double
+          description: Can represent int or float
+        newValue:
+          type: number
+          title: new_value
+          format: double
+      title: NumberFieldChange
+      additionalProperties: false
+    svlog.events.Resource:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        displayName:
+          type: string
+          title: display_name
+      title: Resource
+      additionalProperties: false
+    svlog.events.StringFieldChange:
+      type: object
+      properties:
+        oldValue:
+          type: string
+          title: old_value
+        newValue:
+          type: string
+          title: new_value
+      title: StringFieldChange
+      additionalProperties: false
+    svlog.events.Team:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        displayName:
+          type: string
+          title: display_name
+      title: Team
+      additionalProperties: false
+    svlog.events.Ticket:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: Ticket
+      additionalProperties: false
+    svlog.events.TimestampFieldChange:
+      type: object
+      properties:
+        oldValue:
+          title: old_value
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        newValue:
+          title: new_value
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+      title: TimestampFieldChange
+      additionalProperties: false
+    svlog.events.User:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        displayName:
+          type: string
+          title: display_name
+        email:
+          type: string
+          title: email
+          description: Email serves as display name for users
+        name:
+          type: string
+          title: name
+          description: Full name if available
+      title: User
+      additionalProperties: false
+    svlog.events.UserAddedToTeamEvent:
+      type: object
+      properties:
+        user:
+          title: user
+          $ref: '#/components/schemas/svlog.events.User'
+        team:
+          title: team
+          $ref: '#/components/schemas/svlog.events.Team'
+        role:
+          type: string
+          title: role
+      title: UserAddedToTeamEvent
+      additionalProperties: false
+    svlog.events.UserInvitation:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+      title: UserInvitation
+      additionalProperties: false
+    svlog.events.UserInvitedEvent:
+      type: object
+      properties:
+        invitedUser:
+          title: invited_user
+          $ref: '#/components/schemas/svlog.events.User'
+        invitation:
+          title: invitation
+          $ref: '#/components/schemas/svlog.events.UserInvitation'
+      title: UserInvitedEvent
+      additionalProperties: false
+    svlog.events.UserOrganizationRoleChangedEvent:
+      type: object
+      properties:
+        user:
+          title: user
+          $ref: '#/components/schemas/svlog.events.User'
+        organizationId:
+          type: string
+          title: organization_id
+        oldRole:
+          type: string
+          title: old_role
+        newRole:
+          type: string
+          title: new_role
+      title: UserOrganizationRoleChangedEvent
+      additionalProperties: false
+    svlog.events.UserRemovedFromTeamEvent:
+      type: object
+      properties:
+        user:
+          title: user
+          $ref: '#/components/schemas/svlog.events.User'
+        team:
+          title: team
+          $ref: '#/components/schemas/svlog.events.Team'
+        role:
+          type: string
+          title: role
+          description: The role they had before removal
+      title: UserRemovedFromTeamEvent
+      additionalProperties: false
+    svlog.events.UserTeamRoleChangedEvent:
+      type: object
+      properties:
+        user:
+          title: user
+          $ref: '#/components/schemas/svlog.events.User'
+        team:
+          title: team
+          $ref: '#/components/schemas/svlog.events.Team'
+        oldRole:
+          type: string
+          title: old_role
+        newRole:
+          type: string
+          title: new_role
+      title: UserTeamRoleChangedEvent
+      additionalProperties: false
+    svlog.events.Workflow:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+        displayName:
+          type: string
+          title: display_name
+          description: Should generally include a name where possible as makes it easier to identify the object on export to SIEM without complex hydration
+      title: Workflow
+      additionalProperties: false
+    svlog.events.WorkflowCreatedEvent:
+      type: object
+      properties:
+        workflow:
+          title: workflow
+          $ref: '#/components/schemas/svlog.events.Workflow'
+      title: WorkflowCreatedEvent
+      additionalProperties: false
+    svlog.events.WorkflowDeletedEvent:
+      type: object
+      properties:
+        workflow:
+          title: workflow
+          $ref: '#/components/schemas/svlog.events.Workflow'
+      title: WorkflowDeletedEvent
+      additionalProperties: false
+    svlog.events.WorkflowPublishedEvent:
+      type: object
+      properties:
+        workflow:
+          title: workflow
+          $ref: '#/components/schemas/svlog.events.Workflow'
+        previousVersion:
+          title: previous_version
+          description: null if first published
+          nullable: true
+          $ref: '#/components/schemas/svlog.events.WorkflowVersion'
+        publishedVersion:
+          title: published_version
+          $ref: '#/components/schemas/svlog.events.WorkflowVersion'
+      title: WorkflowPublishedEvent
+      additionalProperties: false
+    svlog.events.WorkflowRun:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: No obvious display name for workflow runs, so we skip that field
+        workflowId:
+          type: string
+          title: workflow_id
+      title: WorkflowRun
+      additionalProperties: false
+    svlog.events.WorkflowRunRequestedEvent:
+      type: object
+      properties:
+        workflow:
+          title: workflow
+          $ref: '#/components/schemas/svlog.events.Workflow'
+        version:
+          title: version
+          $ref: '#/components/schemas/svlog.events.WorkflowVersion'
+        workflowRun:
+          title: workflow_run
+          $ref: '#/components/schemas/svlog.events.WorkflowRun'
+      title: WorkflowRunRequestedEvent
+      additionalProperties: false
+    svlog.events.WorkflowRunStartedEvent:
+      type: object
+      properties:
+        workflow:
+          title: workflow
+          $ref: '#/components/schemas/svlog.events.Workflow'
+        version:
+          title: version
+          $ref: '#/components/schemas/svlog.events.WorkflowVersion'
+        workflowRun:
+          title: workflow_run
+          $ref: '#/components/schemas/svlog.events.WorkflowRun'
+      title: WorkflowRunStartedEvent
+      additionalProperties: false
+    svlog.events.WorkflowUpdatedEvent:
+      type: object
+      properties:
+        workflow:
+          title: workflow
+          $ref: '#/components/schemas/svlog.events.Workflow'
+        version:
+          title: version
+          $ref: '#/components/schemas/svlog.events.WorkflowVersion'
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/svlog.events.FieldChange'
+          title: changes
+          description: What actually changed
+      title: WorkflowUpdatedEvent
+      additionalProperties: false
+    svlog.events.WorkflowVersion:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: This is the version ID, not the workflow ID
+        displayName:
+          type: string
+          title: display_name
+        workflowId:
+          type: string
+          title: workflow_id
+        versionNumber:
+          type: integer
+          title: version_number
+          format: int32
+      title: WorkflowVersion
+      additionalProperties: false
+    svlog.publicapi.ListAuditLogsRequest:
+      type: object
+      properties:
+        pageToken:
+          type: string
+          title: page_token
+          nullable: true
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          nullable: true
+        startTime:
+          title: start_time
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        endTime:
+          title: end_time
+          nullable: true
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+      title: ListAuditLogsRequest
+      additionalProperties: false
+    svlog.publicapi.ListAuditLogsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svlog.events.AuditLogEvent'
+          title: data
+        nextPageToken:
+          type: string
+          title: next_page_token
+          nullable: true
+      title: ListAuditLogsResponse
+      additionalProperties: false
+    svstore.pubapimodels.Entity:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the entity.
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team that the entity belongs to.
+        entityTypeId:
+          type: string
+          title: entity_type_id
+          description: The ID of the entity type.
+        key:
+          type: string
+          title: key
+          description: The unique key for the entity within its type.
+        name:
+          type: string
+          title: name
+          description: The name of the entity.
+        number:
+          type: integer
+          title: number
+          format: int32
+          description: The sequential number for the entity within the team.
+        createdByUserId:
+          type: string
+          title: created_by_user_id
+          description: The ID of the user who created the entity.
+        updatedByUserId:
+          type: string
+          title: updated_by_user_id
+          description: The ID of the user who last updated the entity.
+        createdAt:
+          title: created_at
+          description: The timestamp when the entity was created.
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        updatedAt:
+          title: updated_at
+          description: The timestamp when the entity was last updated.
+          $ref: '#/components/schemas/google.protobuf.Timestamp'
+        document:
+          type: string
+          title: document
+          description: The entity's document data as a JSON string.
+        entityTypeKey:
+          type: string
+          title: entity_type_key
+          description: The key of the entity type.
+        entitySchemaKey:
+          type: string
+          title: entity_schema_key
+          description: The key of the entity schema.
+        entitySchemaId:
+          type: string
+          title: entity_schema_id
+          description: The ID of the entity schema.
+      title: Entity
+      additionalProperties: false
+    svstore.pubapimodels.EntityFieldFilter:
+      type: object
+      oneOf:
+        - properties:
+            valueBool:
+              type: boolean
+              title: value_bool
+          title: value_bool
+          required:
+            - valueBool
+        - properties:
+            valueNumber:
+              type: number
+              title: value_number
+              format: double
+          title: value_number
+          required:
+            - valueNumber
+        - properties:
+            valueText:
+              type: string
+              title: value_text
+          title: value_text
+          required:
+            - valueText
+        - properties:
+            valueTs:
+              title: value_ts
+              $ref: '#/components/schemas/google.protobuf.Timestamp'
+          title: value_ts
+          required:
+            - valueTs
+      properties:
+        fieldId:
+          type: string
+          title: field_id
+          description: Use either field_id or field_key
+          nullable: true
+        fieldKey:
+          type: string
+          title: field_key
+          nullable: true
+        operator:
+          title: operator
+          description: Comparison operator
+          $ref: '#/components/schemas/svstore.pubapimodels.ComparisonOperator'
+      title: EntityFieldFilter
+      additionalProperties: false
+      description: Filter for a single entity field
+    svstore.pubapimodels.EntityFieldFilterGroup:
+      type: object
+      properties:
+        filters:
+          type: array
+          items:
+            $ref: '#/components/schemas/svstore.pubapimodels.EntityFieldFilter'
+          title: filters
+      title: EntityFieldFilterGroup
+      additionalProperties: false
+      description: Group of filters (AND-ed together)
+    svstore.pubapimodels.EntityFieldValue:
+      type: object
+      oneOf:
+        - properties:
+            boolValue:
+              type: boolean
+              title: bool_value
+          title: bool_value
+          required:
+            - boolValue
+        - properties:
+            entityRefValue:
+              type: string
+              title: entity_ref_value
+          title: entity_ref_value
+          required:
+            - entityRefValue
+        - properties:
+            enumValue:
+              type: string
+              title: enum_value
+          title: enum_value
+          required:
+            - enumValue
+        - properties:
+            numberValue:
+              type: number
+              title: number_value
+              format: double
+          title: number_value
+          required:
+            - numberValue
+        - properties:
+            textValue:
+              type: string
+              title: text_value
+          title: text_value
+          required:
+            - textValue
+        - properties:
+            timestampValue:
+              title: timestamp_value
+              $ref: '#/components/schemas/google.protobuf.Timestamp'
+          title: timestamp_value
+          required:
+            - timestampValue
+        - properties:
+            userRefValue:
+              type: string
+              title: user_ref_value
+          title: user_ref_value
+          required:
+            - userRefValue
+      properties:
+        fieldId:
+          type: string
+          title: field_id
+          description: The ID of the field.
+      title: EntityFieldValue
+      additionalProperties: false
+    svstore.pubapimodels.FieldSort:
+      type: object
+      properties:
+        fieldId:
+          type: string
+          title: field_id
+          description: Use either field_id or field_key
+          nullable: true
+        fieldKey:
+          type: string
+          title: field_key
+          nullable: true
+        descending:
+          type: boolean
+          title: descending
+          description: Sort descending (false = ASC, true = DESC)
+      title: FieldSort
+      additionalProperties: false
+      description: Sorting specification for entity fields
+    svstore.publicapi.CreateEntityRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        entityTypeId:
+          type: string
+          title: entity_type_id
+          description: The ID of the entity type.
+        key:
+          type: string
+          title: key
+          description: The unique key for the entity.
+        name:
+          type: string
+          title: name
+          description: The name of the entity.
+        fieldValues:
+          type: array
+          items:
+            $ref: '#/components/schemas/svstore.pubapimodels.EntityFieldValue'
+          title: field_values
+          description: The field values for the entity.
+      title: CreateEntityRequest
+      additionalProperties: false
+    svstore.publicapi.CreateEntityResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The created entity.
+          $ref: '#/components/schemas/svstore.pubapimodels.Entity'
+      title: CreateEntityResponse
+      additionalProperties: false
+    svstore.publicapi.DeleteEntityRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the entity.
+      title: DeleteEntityRequest
+      additionalProperties: false
+    svstore.publicapi.DeleteEntityResponse:
+      type: object
+      title: DeleteEntityResponse
+      additionalProperties: false
+    svstore.publicapi.GetEntityRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the entity.
+      title: GetEntityRequest
+      additionalProperties: false
+    svstore.publicapi.GetEntityResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The entity.
+          $ref: '#/components/schemas/svstore.pubapimodels.Entity'
+      title: GetEntityResponse
+      additionalProperties: false
+    svstore.publicapi.ListEntitiesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        entityTypeId:
+          type: string
+          title: entity_type_id
+          description: Optional filter by entity type ID.
+          nullable: true
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: ListEntitiesRequest
+      additionalProperties: false
+    svstore.publicapi.ListEntitiesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svstore.pubapimodels.Entity'
+          title: data
+          description: The list of entities.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: ListEntitiesResponse
+      additionalProperties: false
+    svstore.publicapi.SearchEntitiesRequest:
+      type: object
+      properties:
+        teamId:
+          type: string
+          title: team_id
+          description: The ID of the team.
+        entityTypeId:
+          type: string
+          title: entity_type_id
+          description: Optional filter by entity type ID.
+          nullable: true
+        entityTypeKey:
+          type: string
+          title: entity_type_key
+          description: Optional filter by entity type key (alternative to entity_type_id).
+          nullable: true
+        filterGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/svstore.pubapimodels.EntityFieldFilterGroup'
+          title: filter_groups
+          description: Filter groups for complex filtering. OR between groups, AND within each group.
+        nameSearch:
+          type: string
+          title: name_search
+          description: Optional text search on entity name.
+          nullable: true
+        fieldSorts:
+          type: array
+          items:
+            $ref: '#/components/schemas/svstore.pubapimodels.FieldSort'
+          title: field_sorts
+          description: Sorting specifications.
+        pageSize:
+          type: integer
+          title: page_size
+          format: int32
+          description: Maximum number of results to return. Default is 1000, maximum is 1000.
+          nullable: true
+        pageToken:
+          type: string
+          title: page_token
+          description: Token for pagination. Leave empty for the first request.
+          nullable: true
+      title: SearchEntitiesRequest
+      additionalProperties: false
+    svstore.publicapi.SearchEntitiesResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/svstore.pubapimodels.Entity'
+          title: data
+          description: The list of matching entities.
+        nextPageToken:
+          type: string
+          title: next_page_token
+          description: Token for retrieving the next page of results. Empty if no more results.
+          nullable: true
+      title: SearchEntitiesResponse
+      additionalProperties: false
+    svstore.publicapi.UpdateEntityRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          title: id
+          description: The ID of the entity.
+        name:
+          type: string
+          title: name
+          description: The name of the entity.
+        fieldValues:
+          type: array
+          items:
+            $ref: '#/components/schemas/svstore.pubapimodels.EntityFieldValue'
+          title: field_values
+          description: The field values to update.
+      title: UpdateEntityRequest
+      additionalProperties: false
+    svstore.publicapi.UpdateEntityResponse:
+      type: object
+      properties:
+        data:
+          title: data
+          description: The updated entity.
+          $ref: '#/components/schemas/svstore.pubapimodels.Entity'
+      title: UpdateEntityResponse
+      additionalProperties: false
+    connect-protocol-version:
+      type: number
+      title: Connect-Protocol-Version
+      enum:
+        - 1
+      description: Define the version of the Connect protocol
+      const: 1
+    connect-timeout-header:
+      type: number
+      title: Connect-Timeout-Ms
+      description: Define the timeout, in ms
+    connect.error:
+      type: object
+      properties:
+        code:
+          type: string
+          examples:
+            - not_found
+          enum:
+            - canceled
+            - unknown
+            - invalid_argument
+            - deadline_exceeded
+            - not_found
+            - already_exists
+            - permission_denied
+            - resource_exhausted
+            - failed_precondition
+            - aborted
+            - out_of_range
+            - unimplemented
+            - internal
+            - unavailable
+            - data_loss
+            - unauthenticated
+          description: The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+        message:
+          type: string
+          description: A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+        detail:
+          $ref: '#/components/schemas/google.protobuf.Any'
+      title: Connect Error
+      additionalProperties: true
+      description: 'Error type returned by Connect: https://connectrpc.com/docs/go/errors/#http-representation'
+    google.protobuf.Any:
+      type: object
+      properties:
+        type:
+          type: string
+        value:
+          type: string
+          format: binary
+        debug:
+          type: object
+          additionalProperties: true
+      additionalProperties: true
+      description: Contains an arbitrary serialized message along with a @type that describes the type of the serialized message.
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+security:
+  - BearerAuth: []
+tags:
+  - name: PublicAPIServiceV2
+    description: OpenAPI documentation for the service v2

--- a/workflowapprovalprocedure.go
+++ b/workflowapprovalprocedure.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 
 	"github.com/ServalHQ/serval-go/internal/apijson"
+	"github.com/ServalHQ/serval-go/internal/apiquery"
 	"github.com/ServalHQ/serval-go/internal/requestconfig"
 	"github.com/ServalHQ/serval-go/option"
 	"github.com/ServalHQ/serval-go/packages/param"
@@ -325,6 +327,53 @@ type WorkflowApprovalProcedureListResponseEnvelope struct {
 // Returns the unmodified JSON received from the API
 func (r WorkflowApprovalProcedureListResponseEnvelope) RawJSON() string { return r.JSON.raw }
 func (r *WorkflowApprovalProcedureListResponseEnvelope) UnmarshalJSON(data []byte) error {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+// List all workflow approval procedures for a team.
+func (r *WorkflowApprovalProcedureService) ListByTeam(ctx context.Context, query WorkflowApprovalProcedureListByTeamParams, opts ...option.RequestOption) (res *WorkflowApprovalProcedureListByTeamResponse, err error) {
+	opts = slices.Concat(r.Options, opts)
+	path := "v2/workflow-approval-procedures"
+	err = requestconfig.ExecuteNewRequest(ctx, http.MethodGet, path, query, &res, opts...)
+	return
+}
+
+type WorkflowApprovalProcedureListByTeamParams struct {
+	// The ID of the team.
+	TeamID param.Opt[string] `query:"teamId,omitzero" json:"-"`
+	// Maximum number of results to return. Default is 1000, maximum is 1000.
+	PageSize param.Opt[int64] `query:"pageSize,omitzero" json:"-"`
+	// Token for pagination. Leave empty for the first request.
+	PageToken param.Opt[string] `query:"pageToken,omitzero" json:"-"`
+	paramObj
+}
+
+// URLQuery serializes [WorkflowApprovalProcedureListByTeamParams]'s query
+// parameters as `url.Values`.
+func (r WorkflowApprovalProcedureListByTeamParams) URLQuery() (v url.Values, err error) {
+	return apiquery.MarshalWithSettings(r, apiquery.QuerySettings{
+		ArrayFormat:  apiquery.ArrayQueryFormatComma,
+		NestedFormat: apiquery.NestedQueryFormatBrackets,
+	})
+}
+
+type WorkflowApprovalProcedureListByTeamResponse struct {
+	// The list of workflow approval procedures for the team.
+	Data []WorkflowApprovalProcedure `json:"data"`
+	// Token for retrieving the next page of results. Empty if no more results.
+	NextPageToken string `json:"nextPageToken,nullable"`
+	// JSON contains metadata for fields, check presence with [respjson.Field.Valid].
+	JSON struct {
+		Data          respjson.Field
+		NextPageToken respjson.Field
+		ExtraFields   map[string]respjson.Field
+		raw           string
+	} `json:"-"`
+}
+
+// Returns the unmodified JSON received from the API
+func (r WorkflowApprovalProcedureListByTeamResponse) RawJSON() string { return r.JSON.raw }
+func (r *WorkflowApprovalProcedureListByTeamResponse) UnmarshalJSON(data []byte) error {
 	return apijson.UnmarshalRoot(data, r)
 }
 


### PR DESCRIPTION
## Summary

- Add `ListByTeam` methods to `AccessPolicyApprovalProcedureService` and `WorkflowApprovalProcedureService`
- New endpoints: `GET /v2/access-policy-approval-procedures?teamId=...` and `GET /v2/workflow-approval-procedures?teamId=...`
- These return all approval procedures for a team in a single paginated call, with the parent ID (`accessPolicyId` / `workflowId`) included on each item
- Includes updated `openapi.yaml` with new endpoint and schema definitions

## Motivation

The terraform-provider-serval currently uses a two-phase prefetch: Phase 1 fetches workflows/access policies by team, then Phase 2 iterates over each parent ID to fetch approval procedures one-by-one. With these new team-scoped endpoints, the provider can fetch all approval procedures in Phase 1 alongside everything else, eliminating the sequential Phase 2 entirely.

## Test plan

- [x] `go build ./...` passes
- [ ] Verify with terraform-provider-serval integration (companion PR)


Made with [Cursor](https://cursor.com)